### PR TITLE
[BOSK-4] feat: Add initial blocks interface

### DIFF
--- a/bosk/__init__.py
+++ b/bosk/__init__.py
@@ -1,1 +1,16 @@
 __version__ = '0.1'
+
+
+from .data import Data
+from .stages import Stages
+from .slot import BaseSlot, BlockInputSlot, BlockOutputSlot, SlotT
+
+
+__all__ = [
+    "Data",
+    "Stages",
+    "BaseSlot",
+    "BlockInputSlot",
+    "BlockOutputSlot",
+    "SlotT",
+]

--- a/bosk/block/__init__.py
+++ b/bosk/block/__init__.py
@@ -1,5 +1,5 @@
 from .meta import BlockMeta, BlockInputSlot, BlockOutputSlot
-from .base import BaseBlock, BlockInputData, BlockOutputData
+from .base import BaseBlock, BlockInputData, BlockOutputData, auto_block
 
 
 __all__ = [
@@ -9,4 +9,5 @@ __all__ = [
     "BlockInputData",
     "BlockOutputData",
     "BaseBlock",
+    "auto_block",
 ]

--- a/bosk/block/__init__.py
+++ b/bosk/block/__init__.py
@@ -1,0 +1,12 @@
+from .meta import BlockMeta, BlockInputSlot, BlockOutputSlot
+from .base import BaseBlock, BlockInputData, BlockOutputData
+
+
+__all__ = [
+    "BlockInputSlot",
+    "BlockOutputSlot",
+    "BlockMeta",
+    "BlockInputData",
+    "BlockOutputData",
+    "BaseBlock",
+]

--- a/bosk/block/base.py
+++ b/bosk/block/base.py
@@ -1,0 +1,101 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, List, Any, Mapping, Sequence, TypeVar
+from .meta import BlockMeta
+from ..slot import BlockInputSlot, BlockOutputSlot
+from ..data import Data
+
+
+BlockT = TypeVar('BlockT', bound='BaseBlock')
+"""Block generic typevar.
+"""
+
+
+BlockInputData = Mapping[BlockInputSlot, Data]
+"""Block input values container data type.
+
+It is indexed by input slots, not their names.
+"""
+
+BlockOutputData = Mapping[BlockOutputSlot, Data]
+"""Block output values container data type.
+
+It is indexed by output slots, not their names.
+"""
+
+
+class BaseBlock(ABC):
+    """Base block, the parent of every computation block.
+
+    Attributes:
+        meta: Meta information of the block.
+
+    """
+    @property
+    def meta(self):
+        ...
+
+    @meta.getter
+    @abstractmethod
+    def meta(self):
+        """Meta information property getter.
+
+        Children classes must specify meta.
+        It can be implemented as an attribute without redefining a property, for example::
+
+            class StubBlock(BaseBlock):
+                meta = BlockMeta(...)
+
+        """
+
+    @abstractmethod
+    def fit(self, inputs: BlockInputData) -> BlockT:
+        """Fit the block on the given input data.
+
+        Args:
+            inputs: Block input data for the fitting stage.
+
+        Returns:
+            Self.
+
+        """
+
+    @abstractmethod
+    def transform(self, inputs: BlockInputData) -> BlockOutputData:
+        """Transform the given input data, i.e. compute values for each output slot.
+
+        Args:
+            inputs: Block input data for the transforming stage.
+
+        Returns:
+            Outputs calculated for the given inputs.
+
+        """
+
+    def get(self, inputs: BlockInputData, slot_name: str) -> Data:
+        """Get input value by name.
+
+        Args:
+            inputs: Block inputs, passed to the instance.
+            slot_name: Input slot name.
+
+        Returns:
+            Input data value.
+
+        """
+        return inputs[self.meta.inputs[slot_name]]
+
+    def wrap(self, output_values: Mapping[str, Data]) -> BlockOutputData:
+        """Wrap outputs dictionary into ``BlockOutputs`` object.
+
+        Args:
+            output_values: Dictionary of values indexed by slot names.
+
+        Returns:
+            Block outputs object indexed by slots.
+
+        """
+        return {
+            self.meta.outputs[slot_name]: value
+            for slot_name, value in output_values.items()
+        }

--- a/bosk/block/base.py
+++ b/bosk/block/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Any, Mapping, Sequence, TypeVar
+from typing import Dict, List, Any, Mapping, Sequence, TypeVar, Type
 from .meta import BlockMeta
 from ..slot import BlockInputSlot, BlockOutputSlot
 from ..data import Data
@@ -99,3 +99,46 @@ class BaseBlock(ABC):
             self.meta.outputs[slot_name]: value
             for slot_name, value in output_values.items()
         }
+
+
+def auto_block(cls: Type[BaseBlock]):
+    """Convert any fit-transform class into a block.
+    
+    Args:
+        cls: Class with fit-transform interface.
+
+    Returns:
+        Block class.
+    
+    """
+
+    class AutoBlock(BaseBlock):
+        meta = BlockMeta(
+            inputs=[
+                BlockInputSlot(name=name)
+                for name in cls.fit.__code__.co_varnames[:cls.fit.__code__.co_argcount]
+            ],
+            outputs=[
+                BlockOutputSlot(name='output')
+            ],
+        )
+
+        def __init__(self, *args, **kwargs):
+            self.__instance = cls(*args, **kwargs)
+
+        def __prepare_kwargs(self, inputs: BlockInputData) -> Mapping[BlockInputSlot, Data]:
+            kwargs = {
+                slot_name: self.get(inputs, slot_name)
+                for slot_name in self.meta.inputs.keys()
+            }
+            return kwargs
+
+        def fit(self, inputs: BlockInputData) -> 'AutoBlock':
+            self.__instance.fit(self, **self.__prepare_kwargs(inputs))
+            return self
+        
+        def transform(self, inputs: BlockInputData) -> BlockOutputData:
+            transformed = self.__instance.transform(self, **self.__prepare_kwargs(inputs))
+            return self.wrap({'output': transformed})
+
+    return AutoBlock

--- a/bosk/block/meta.py
+++ b/bosk/block/meta.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Mapping, List
+from ..slot import BlockInputSlot, BlockOutputSlot, SlotT
+
+
+@dataclass(init=False)
+class BlockMeta:
+    inputs: Mapping[str, BlockInputSlot]
+    outputs: Mapping[str, BlockOutputSlot]
+
+    def __list_of_slots_to_mapping(self, slots_list: List[SlotT]) -> Mapping[str, SlotT]:
+        return {
+            slot.name: slot
+            for slot in slots_list
+        }
+
+    def __init__(self, *, inputs=None, outputs=None):
+        assert inputs is not None, 'Meta inputs description is required'
+        assert outputs is not None, 'Meta outputs description is required'
+        self.inputs = self.__list_of_slots_to_mapping(inputs)
+        self.outputs = self.__list_of_slots_to_mapping(outputs)

--- a/bosk/data.py
+++ b/bosk/data.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+
+Data = Any
+"""Type for data which will be transferred between blocks.
+"""

--- a/bosk/slot.py
+++ b/bosk/slot.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import TypeVar
+from .stages import Stages
+
+
+@dataclass(eq=True, frozen=True)
+class BaseSlot:
+    """Base slot.
+
+    Slot is a named placeholder for data.
+
+    Attributes:
+        name: Slot name.
+        stages: At which stages slot value is needed.
+    """
+    name: str
+    stages: Stages = Stages()
+
+
+@dataclass(eq=True, frozen=True)
+class BlockInputSlot(BaseSlot):
+    """Block input slot.
+
+    Contains the information required for the input data processing, and input-output matching.
+    """
+
+
+@dataclass(eq=True, frozen=True)
+class BlockOutputSlot(BaseSlot):
+    """Block output slot.
+
+    Contains the information about the output data for input-output matching.
+    """
+
+
+SlotT = TypeVar('SlotT', bound=BaseSlot)
+"""Slot generic typevar.
+"""

--- a/bosk/stages.py
+++ b/bosk/stages.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(eq=True, frozen=True)
+class Stages:
+    fit: bool = True
+    transform: bool = True


### PR DESCRIPTION
**Quick interface summary:**

Each block should implement two methods: `fit` and `transform`; and specify meta information with input&output slots (data placeholders).