### PR TITLE
[BOSK-73] Implement auto serialization in auto_block, fix some blocks

### DIFF
--- a/bosk/block/zoo/data_weighting/data_weighting.py
+++ b/bosk/block/zoo/data_weighting/data_weighting.py
@@ -3,7 +3,7 @@ import numpy as np
 from bosk.block import auto_block
 
 
-@auto_block
+@auto_block(auto_state=True)
 class WeightsBlock:
     def __init__(self, ord: int = 1):
         self._weights = None

--- a/bosk/block/zoo/multi_grained_scanning/multi_grained_scanning_1d.py
+++ b/bosk/block/zoo/multi_grained_scanning/multi_grained_scanning_1d.py
@@ -6,7 +6,7 @@ from bosk.block.zoo.multi_grained_scanning.multi_grained_scanning import MultiGr
 from bosk.block import auto_block
 
 
-@auto_block
+@auto_block(auto_state=True)
 class MultiGrainedScanning1DBlock(MultiGrainedScanningBlock):
     def _window_slicing_data(self, X, y=None) -> 'Tuple[np.ndarray, Optional[np.ndarray]]':
         shape = X.shape[1]

--- a/bosk/block/zoo/multi_grained_scanning/multi_grained_scanning_2d.py
+++ b/bosk/block/zoo/multi_grained_scanning/multi_grained_scanning_2d.py
@@ -7,7 +7,7 @@ from bosk.block import auto_block
 from bosk.block.zoo.multi_grained_scanning.multi_grained_scanning import MultiGrainedScanningBlock
 
 
-@auto_block
+@auto_block(auto_state=True)
 class MultiGrainedScanning2DBlock(MultiGrainedScanningBlock):
     def _window_slicing_data(self, X, y=None) -> 'Tuple[np.ndarray, Optional[np.ndarray]]':
         shape = self._shape_sample


### PR DESCRIPTION
* The auto-serialization flag (`auto_state`) has been added to `auto_block`;
* For several blocks (`WeightsBlock`, `MultiGrainedScanning<...>`) the `auto_state` flag has been set to `True`.

**Rationale:**
Blocks can be constructed with a fit-transform class and `auto_block` decorator.
Any block that implement `__getstate__` and `__setstate__` methods can be serialized.
But otherwise the only way to serialize an instance (persist the state) is to serialize `__dict__`.
The problem is that we cannot guarantee that the class instance can be fully represented with its `__dict__` (e.g. if the instance has allocated some memory and `__dict__` contains only pointer to it), so the one who implements the block logic should decide how to extract the state.
To avoid boilerplate code that implements `__getstate__` and `__setstate__` based on the instance `__dict__`, the new flag for `auto_block` decorator has been proposed: `auto_state`. If it is *True*, then the case when `__dict__` fully represents the state is considered. Otherwise, the fit-transform class has to implement these methods, or exception will be raised.