### PR TITLE
[BOSK-85] Add Random Ferns and Multi-Grained Scanning Random Ferns

### DIFF
--- a/bosk/block/zoo/models/classification/__init__.py
+++ b/bosk/block/zoo/models/classification/__init__.py
@@ -1,1 +1,3 @@
 from .classification_models import RFCBlock, ETCBlock, CatBoostClassifierBlock, XGBClassifierBlock
+from .ferns import RandomFernsBlock
+from .mgs_ferns import MGSRandomFernsBlock

--- a/bosk/block/zoo/models/classification/ferns.py
+++ b/bosk/block/zoo/models/classification/ferns.py
@@ -1,0 +1,342 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import random
+from functools import partial
+from sklearn.utils.multiclass import check_classification_targets
+from joblib import Parallel, delayed
+from typing import Optional
+
+
+from ....base import BaseBlock, TransformOutputData, BlockInputData
+from ....meta import BlockMeta, BlockExecutionProperties
+from ....slot import InputSlotMeta, OutputSlotMeta
+from .....stages import Stages
+from .....data import CPUData, GPUData
+from .....utility import get_random_generator, get_rand_int
+
+
+@partial(jax.jit, static_argnames=('n_ferns', 'fern_size'))
+def make_unary_ferns(xs: jnp.ndarray, n_ferns: int, fern_size: int, key: random.PRNGKey):
+    """Generate indices and threshold values for unary fern.
+    An unary fern represents a function that maps x to an integer number:
+        x -> [ x[i[0]] >= t[0], ..., x[i[k]] >= t[k] ].
+
+    Args:
+        xs: Input data of shape (n_samples, n_features).
+        n_ferns: Number of ferns to generate.
+        fern_size: Size of fern (statistics array size is exponential to the size of fern).
+        key: PRNG Key.
+
+    Returns:
+        Pair (feature indices, feature thresholds), both of shape (n_ferns, fern_size).
+
+    """
+    n_features = xs.shape[1]
+    ft_key, fi_key = random.split(key)
+    n_indices = n_ferns * fern_size
+    feature_indices = random.randint(fi_key, (n_indices,), minval=0, maxval=n_features)
+    mins = xs[:, feature_indices].min(axis=0)
+    maxs = xs[:, feature_indices].max(axis=0)
+    feature_thresholds = random.uniform(
+        ft_key,
+        (n_indices,),
+        minval=mins,
+        maxval=maxs,
+    )
+    return feature_indices.reshape((n_ferns, fern_size)), feature_thresholds.reshape((n_ferns, fern_size))
+
+
+@jax.jit
+def apply_unary_ferns(xs: jnp.ndarray, feature_indices, feature_thresholds):
+    """Compute the bucket indices.
+
+    Args:
+        xs: Input data of shape (n_samples, n_features).
+        feature_indices: Ferns feature indices of shape (n_ferns, fern_size).
+        feature_thresholds: Ferns thresholds of shape (n_ferns, fern_size).
+
+    Returns:
+        Bucket indices of shape (n_samples, n_ferns).
+
+    """
+    fern_size = feature_indices.shape[1]
+    index_multipliers = 2 ** jnp.arange(fern_size)
+    predicates = (xs[:, feature_indices] >= feature_thresholds[jnp.newaxis])
+    # predicates shape: (n_samples, n_ferns, fern_size)
+    bucket_indices = predicates @ index_multipliers
+    # bucket_indices shape: (n_samples, n_ferns)
+    return bucket_indices
+
+
+@partial(jax.jit, static_argnames=('n_ferns', 'fern_size'))
+def make_binary_ferns(xs: jnp.ndarray, n_ferns: int, fern_size: int, key: random.PRNGKey):
+    """Generate indices and threshold values for unary fern.
+    An unary fern represents a function that maps x to an integer number:
+        x -> [ x[i[0]] >= x[j[0]], ..., x[i[k]] >= x[j[k]] ].
+
+    Args:
+        xs: Input data of shape (n_samples, n_features).
+        n_ferns: Number of ferns to generate.
+        fern_size: Size of fern (statistics array size is exponential to the size of fern).
+        key: PRNG Key.
+
+    Returns:
+        Pair (feature indices left, feature indices right).
+
+    """
+    n_features = xs.shape[1]
+    left_key, right_key = random.split(key)
+    n_indices = n_ferns * fern_size
+    left_indices = random.randint(left_key, (n_indices,), minval=0, maxval=n_features)
+    right_indices = random.randint(right_key, (n_indices,), minval=0, maxval=n_features)
+    return left_indices.reshape((n_ferns, fern_size)), right_indices.reshape((n_ferns, fern_size))
+
+
+@jax.jit
+def apply_binary_ferns(xs: jnp.ndarray, left_indices, right_indices):
+    """Compute the bucket indices.
+    For each sample and fern bucket index indicates to which bucket the sample is assigned.
+
+    Args:
+        xs: Input data of shape (n_samples, n_features).
+        left_indices: Ferns left feature indices of shape (n_ferns, fern_size).
+        right_indices: Ferns right feature indices of shape (n_ferns, fern_size).
+
+    Returns:
+        Bucket indices of shape (n_samples, n_ferns).
+
+    """
+    fern_size = left_indices.shape[1]
+    index_multipliers = 2 ** jnp.arange(fern_size)
+    predicates = (xs[:, left_indices] >= xs[:, right_indices])
+    # predicates shape: (n_samples, n_ferns, fern_size)
+    bucket_indices = predicates @ index_multipliers
+    # bucket_indices shape: (n_samples, n_ferns)
+    return bucket_indices
+
+
+@partial(jax.jit, static_argnames=('n_buckets', 'n_classes'))
+def calculate_bucket_stats(bucket_indices: jnp.ndarray, n_buckets: int, y: jnp.ndarray, n_classes: int):
+    """Calculate bucket statistics for each class.
+
+    Args:
+        bucket_indices: Bucket indices of shape (n_samples, n_ferns).
+        n_buckets: Number of buckets (maximum value of `bucket_indices`).
+        y: Target class values.
+        n_classes: Number of classes.
+
+    Returns:
+        Bucket statistics of shape (n_classes, n_ferns, n_buckets).
+
+    """
+    DIRICHLET_EPS = 1
+
+    bucket_stats = []
+    for c in range(n_classes):
+        class_ind = jnp.where(y == c, 1, 0)
+        bucket_stats.append(
+            jax.vmap(lambda b: jnp.zeros((n_buckets,)).at[b].add(class_ind), in_axes=1, out_axes=0)(bucket_indices)
+        )
+    bucket_stats = jnp.stack(bucket_stats, axis=0)
+    bucket_stats = bucket_stats + DIRICHLET_EPS  # Dirichlet prior (to avoid zero probabilities)
+    bucket_stats = bucket_stats / bucket_stats.sum(axis=2)[:, :, jnp.newaxis]
+    # bucket_stats shape: (n_classes, n_ferns, n_buckets)
+    return bucket_stats
+
+
+def predict_proba(pred_bucket_indices: jnp.ndarray, bucket_stats: jnp.ndarray, prior: jnp.ndarray) -> jnp.ndarray:
+    """Predict probabilities with ferns.
+
+    Args:
+        pred_bucket_indices: Test points bucket indices of shape (n_samples, n_ferns).
+        bucket_stats: Bucket stats of shape (n_classes, n_ferns, n_buckets).
+        prior: Prior distribution on classes of shape (n_classes).
+
+    Returns:
+        Class probabilities of shape (n_samples, n_classes).
+
+    """
+    n_samples = pred_bucket_indices.shape[0]
+    n_ferns = pred_bucket_indices.shape[1]
+    n_classes = bucket_stats.shape[0]
+    # renormalize bucket stats along classes
+    # bucket_renormalized = jnp.log(bucket_stats)
+    # bucket_renormalized = bucket_renormalized - bucket_renormalized.sum(axis=0)[jnp.newaxis]
+    bucket_renormalized = bucket_stats / bucket_stats.sum(axis=0)[jnp.newaxis]
+    bucket_renormalized = jnp.log(bucket_renormalized)
+    # now bucket_renormalized is a conditional probability P(C | Bucket) for each fern (independently).
+
+    # extract fern probabilities for each sample using the given bucket indices and renormalized buckets
+    fern_log_proba = jnp.take_along_axis(bucket_renormalized, pred_bucket_indices.T[np.newaxis], axis=2)
+    # fern_proba shape: (n_classes, n_ferns, n_samples)
+    fern_log_proba = jnp.transpose(fern_log_proba, (2, 0, 1))
+    # fern_proba shape: (n_samples, n_classes, n_ferns)
+    assert fern_log_proba.shape[0] == n_samples
+    assert fern_log_proba.shape[1] == n_classes
+    assert fern_log_proba.shape[2] == n_ferns
+
+    proba = fern_log_proba.sum(axis=2)
+    proba = jnp.exp(proba)
+    # proba shape: (n_samples, n_classes)
+    # multiply by prior and normalize
+    proba = proba * prior[jnp.newaxis]
+    proba = proba / proba.sum(axis=1)[:, jnp.newaxis]
+    return proba
+
+
+class RandomFernsBlock(BaseBlock):
+    """Random Ferns Classifier Block.
+
+    """
+    meta = BlockMeta(
+        inputs=[
+            InputSlotMeta(
+                name='X',
+                stages=Stages(transform=True),
+            ),
+            InputSlotMeta(
+                name='y',
+                stages=Stages(transform=False, transform_on_fit=True),
+            )
+        ],
+        outputs=[
+            OutputSlotMeta(
+                name='probas',
+            )
+        ],
+        execution_props=BlockExecutionProperties(gpu=True),
+    )
+
+    def __init__(self, n_groups: int = 10,
+                 n_ferns_in_group: int = 20,
+                 fern_size: int = 7,
+                 kind: str = 'unary',
+                 bootstrap: bool = False,
+                 n_jobs: Optional[int] = None,
+                 random_state: Optional[int] = None):
+        """Initialize Random Ferns Block.
+
+        Args:
+            n_groups: Number of ferns groups (like a number of estimators).
+            n_ferns_in_group: Number of ferns in a group.
+            fern_size: Number of tests in fern.
+            kind: Kind of tests ('unary' or 'binary').
+            bootstrap: Apply data bootstrap or not.
+            n_jobs: Number of threads.
+            random_state: Random state.
+
+        """
+        super().__init__()
+        assert fern_size <= 32, 'Maximum number of tests in a fern is 32'
+        self.n_groups = n_groups
+        self.n_ferns_in_group = n_ferns_in_group
+        self.n_ferns = n_ferns_in_group * n_groups
+        self.fern_size = fern_size
+        self.kind = kind
+        self.n_buckets = 2 ** fern_size
+        self.bootstrap = bootstrap
+        self.n_jobs = n_jobs
+        self.random_state = random_state
+
+    def _classifier_init(self, y):
+        check_classification_targets(y)
+
+        self.classes_, y_encoded = jnp.unique(y, return_inverse=True)
+        self.n_classes_ = len(self.classes_)
+        y = y_encoded
+        return y
+
+    def _parallel_calc_bucket_stats(self, bucket_indices, y, group_data_indices):
+        bucket_stats = Parallel(n_jobs=self.n_jobs, prefer='threads')(
+            delayed(calculate_bucket_stats)(
+                bucket_indices[
+                    data_ids,
+                    slice(i * self.n_ferns_in_group, (i + 1) * self.n_ferns_in_group)
+                ],
+                self.n_buckets,
+                y[data_ids],
+                n_classes=self.n_classes_
+            )
+            for i, data_ids in enumerate(group_data_indices)
+        )
+        bucket_stats = jnp.concatenate(bucket_stats, axis=1)
+        return bucket_stats
+
+    def _make_ferns(self, X, prng_key):
+        if self.kind == 'unary':
+            return make_unary_ferns(X, n_ferns=self.n_ferns, fern_size=self.fern_size, key=prng_key)
+        elif self.kind == 'binary':
+            return make_binary_ferns(X, n_ferns=self.n_ferns, fern_size=self.fern_size, key=prng_key)
+        else:
+            raise ValueError(f'Wrong kind: {self.kind!r}')
+
+    def _apply_ferns(self, X, ferns):
+        if self.kind == 'unary':
+            return apply_unary_ferns(X, *ferns)
+        elif self.kind == 'binary':
+            return apply_binary_ferns(X, *ferns)
+        else:
+            raise ValueError(f'Wrong kind: {self.kind!r}')
+
+    def fit(self, inputs: BlockInputData) -> 'RandomFernsBlock':
+        """Fit the Random Ferns Block.
+        The implementation is device-agnostic.
+
+        """
+        assert type(inputs['X']) == type(inputs['y'])
+        X = inputs['X'].data
+        y = inputs['y'].data
+        y = self._classifier_init(y)
+        np_rng = get_random_generator(self.random_state)
+        prng_key = random.PRNGKey(get_rand_int(np_rng))
+        prng_key, ferns_key = random.split(prng_key)
+        n_samples = X.shape[0]
+
+        ferns = self._make_ferns(X, ferns_key)
+        bucket_indices = self._apply_ferns(X, ferns)
+
+        if not self.bootstrap:
+            group_data_indices = [slice(None, None) for _ in range(self.n_groups)]
+        else:
+            keys = random.split(prng_key, self.n_groups)
+            group_data_indices = [
+                random.choice(keys[i], n_samples, shape=(n_samples,), replace=True)
+                for i in range(self.n_groups)
+            ]
+
+        if self.n_jobs is None and not self.bootstrap:
+            bucket_stats = calculate_bucket_stats(bucket_indices, self.n_buckets, y, n_classes=self.n_classes_)
+        else:
+            bucket_stats = self._parallel_calc_bucket_stats(bucket_indices, y, group_data_indices)
+
+        _classes, counts = jnp.unique(y, return_counts=True)
+        self.prior_ = counts / counts.sum()
+        self.ferns_ = ferns
+        self.bucket_stats_ = bucket_stats
+        return self
+
+    def _predict_proba(self, X):
+        group_preds = []
+        for group_indices in jnp.split(jnp.arange(self.n_ferns), self.n_groups):
+            prediction_bucket_indices = self._apply_ferns(X, [f[group_indices] for f in self.ferns_])
+            group_preds.append(
+                predict_proba(
+                    prediction_bucket_indices,
+                    self.bucket_stats_[:, group_indices],
+                    prior=self.prior_
+                )
+            )
+        preds = jnp.stack(group_preds, axis=0).mean(axis=0)
+        return preds
+
+    def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        X = inputs['X'].data
+
+        result = self._predict_proba(X)
+        if type(inputs['X']) == CPUData:
+            return {'probas': CPUData(np.asarray(result))}
+        elif type(inputs['X']) == GPUData:
+            return {'probas': GPUData(result)}
+        else:
+            raise NotImplementedError(f'Not implemented for input type: {type(inputs["X"])!r}')

--- a/bosk/block/zoo/models/classification/ferns.py
+++ b/bosk/block/zoo/models/classification/ferns.py
@@ -245,9 +245,8 @@ class RandomFernsBlock(BaseBlock):
         ATTRS = (
             'n_groups', 'n_ferns_in_group', 'n_ferns', 'fern_size',
             'kind', 'n_buckets', 'bootstrap', 'n_jobs', 'random_state',
-            'n_classes_'
+            'n_classes_',
             'slots',  # BaseBlock attribute
-
         )
         state = {
             k: getattr(self, k)

--- a/bosk/block/zoo/models/classification/ferns.py
+++ b/bosk/block/zoo/models/classification/ferns.py
@@ -245,7 +245,9 @@ class RandomFernsBlock(BaseBlock):
         ATTRS = (
             'n_groups', 'n_ferns_in_group', 'n_ferns', 'fern_size',
             'kind', 'n_buckets', 'bootstrap', 'n_jobs', 'random_state',
-            'n_classes_',
+            'n_classes_'
+            'slots',  # BaseBlock attribute
+
         )
         state = {
             k: getattr(self, k)

--- a/bosk/block/zoo/models/classification/mgs_ferns.py
+++ b/bosk/block/zoo/models/classification/mgs_ferns.py
@@ -1,0 +1,411 @@
+from operator import mul
+from joblib import Parallel, delayed
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax import random
+from sklearn.utils.multiclass import check_classification_targets
+from typing import Optional, Tuple, Union
+from functools import partial, reduce
+
+from ....base import BaseBlock, TransformOutputData, BlockInputData
+from ....meta import BlockMeta, BlockExecutionProperties
+from ....slot import InputSlotMeta, OutputSlotMeta
+from .....stages import Stages
+from .....data import CPUData, GPUData
+from .....utility import get_random_generator, get_rand_int
+from ...multi_grained_scanning._convolution_helpers import _ConvolutionParams, _ConvolutionHelper
+from .ferns import calculate_bucket_stats, predict_proba
+
+
+@partial(jax.jit, static_argnames=('n_channels', 'window_size', 'n_ferns', 'fern_size'))
+def make_window_unary_ferns(xs: jnp.ndarray,
+                            n_channels: int,
+                            window_size: int,
+                            n_ferns: int,
+                            fern_size: int,
+                            key: random.PRNGKey):
+    """Generate indices and threshold values for unary fern that is applied to a sliding window.
+    The sliding window captures all channels simultaneously.
+
+    Args:
+        xs: Input data of shape (n_samples, n_channels, n_1, ..., n_k).
+        n_channels: Number of input data channels.
+        window_size: Flattened window size.
+        n_ferns: Number of ferns to generate.
+        fern_size: Size of fern (statistics array size is exponential to the size of fern).
+        key: PRNG Key.
+
+    Returns:
+        Pair (feature indices, feature thresholds), both of shape (n_ferns, fern_size).
+
+    """
+    total_window_size = n_channels * window_size
+    ft_key, fi_key = random.split(key)
+    n_indices = n_ferns * fern_size
+    feature_indices = random.randint(fi_key, (n_indices,), minval=0, maxval=total_window_size)
+    mins = xs.min()
+    maxs = xs.max()
+    feature_thresholds = random.uniform(
+        ft_key,
+        (n_indices,),
+        minval=mins,
+        maxval=maxs,
+    )
+    return feature_indices.reshape((n_ferns, fern_size)), feature_thresholds.reshape((n_ferns, fern_size))
+
+
+@partial(jax.jit, static_argnames=('n_channels', 'n_corners', 'n_kernel_points', 'pooled_shape'))
+def apply_window_unary_ferns(xs: jnp.ndarray, raveled_pooling_indices,
+                             n_channels, n_corners, n_kernel_points,
+                             pooled_shape,
+                             feature_indices, feature_thresholds):
+    """Compute the bucket indices for each sliding window.
+
+    Args:
+        xs: Input data of shape (n_samples, n_channels * n_1 * ... * n_k).
+        raveled_pooling_indices: Raveled indices of elements of each window.
+        n_channels: Number of channels.
+        n_corners: Number of corners.
+        n_kernel_points: Number of points in kernel.
+        pooled_shape: Pooled shape.
+        feature_indices: Ferns feature indices of shape (n_ferns, fern_size).
+        feature_thresholds: Ferns thresholds of shape (n_ferns, fern_size).
+
+    Returns:
+        Bucket indices of shape (n_samples, n_1, ..., n_k, n_ferns).
+
+    """
+    n_ferns = feature_indices.shape[0]
+    fern_size = feature_indices.shape[1]
+    index_multipliers = 2 ** jnp.arange(fern_size)
+
+    result = jax.vmap(
+        lambda x: (
+            (
+                x[raveled_pooling_indices].reshape((
+                    n_channels, n_corners, n_kernel_points
+                )).swapaxes(0, 1).reshape((n_corners, -1))[:, feature_indices] >= feature_thresholds[jnp.newaxis]
+            ) @ index_multipliers
+        ).reshape((*pooled_shape, n_ferns)),
+        in_axes=0,
+        out_axes=0
+    )(xs)
+    return result
+
+
+@partial(jax.jit, static_argnames=('n_channels', 'window_size', 'n_ferns', 'fern_size'))
+def make_window_binary_ferns(n_channels: int,
+                             window_size: int,
+                             n_ferns: int,
+                             fern_size: int,
+                             key: random.PRNGKey):
+    """Generate pair indices for binary fern which is applied to a sliding window.
+    The sliding window captures all channels simultaneously.
+
+    Args:
+        xs: Input data of shape (n_samples, n_channels, n_1, ..., n_k).
+        n_channels: Number of input data channels.
+        window_size: Flattened window size.
+        n_ferns: Number of ferns to generate.
+        fern_size: Size of fern (statistics array size is exponential to the size of fern).
+        key: PRNG Key.
+
+    Returns:
+        Pair (feature indices left, feature indices right).
+
+    """
+    total_window_size = n_channels * window_size
+    left_key, right_key = random.split(key)
+    n_indices = n_ferns * fern_size
+    left_indices = random.randint(left_key, (n_indices,), minval=0, maxval=total_window_size)
+    right_indices = random.randint(right_key, (n_indices,), minval=0, maxval=total_window_size)
+    return left_indices.reshape((n_ferns, fern_size)), right_indices.reshape((n_ferns, fern_size))
+
+
+@partial(jax.jit, static_argnames=('n_channels', 'n_corners', 'n_kernel_points', 'pooled_shape'))
+def apply_window_binary_ferns(xs: jnp.ndarray, raveled_pooling_indices,
+                              n_channels, n_corners, n_kernel_points,
+                              pooled_shape,
+                              left_indices, right_indices):
+    """Compute the bucket indices for each sliding window.
+
+    Args:
+        xs: Input data of shape (n_samples, n_channels * n_1 * ... * n_k).
+        raveled_pooling_indices: Raveled indices of elements of each window.
+        n_channels: Number of channels.
+        n_corners: Number of corners.
+        n_kernel_points: Number of points in kernel.
+        pooled_shape: Pooled shape.
+        left_indices: Ferns left feature indices of shape (n_ferns, fern_size).
+        right_indices: Ferns right feature indices of shape (n_ferns, fern_size).
+
+    Returns:
+        Bucket indices of shape (n_samples, n_ferns).
+
+    """
+    n_ferns = left_indices.shape[0]
+    fern_size = left_indices.shape[1]
+    index_multipliers = 2 ** jnp.arange(fern_size)
+
+    compare = lambda x: (x[:, left_indices] >= x[:, right_indices])
+
+    result = jax.vmap(
+        lambda x: (
+            compare(
+                x[raveled_pooling_indices].reshape((
+                    n_channels, n_corners, n_kernel_points
+                )).swapaxes(0, 1).reshape((n_corners, -1))
+            ) @ index_multipliers
+        ).reshape((*pooled_shape, n_ferns)),
+        in_axes=0,
+        out_axes=0
+    )(xs)
+    return result
+
+
+class MGSRandomFernsBlock(BaseBlock):
+    """Multi-Grained Scanning Random Ferns Classifier Block.
+    It applies multiple tests to each sample across spatial dimensions.
+    The result is of the same shape as pooling result (with the same convolution parameters).
+
+    The implementation is based on idea that each patch can be considered as a separate training sample.
+
+    """
+    meta = BlockMeta(
+        inputs=[
+            InputSlotMeta(
+                name='X',
+                stages=Stages(transform=True),
+            ),
+            InputSlotMeta(
+                name='y',
+                stages=Stages(transform=False, transform_on_fit=True),
+            )
+        ],
+        outputs=[
+            OutputSlotMeta(
+                name='probas',
+            )
+        ],
+        execution_props=BlockExecutionProperties(gpu=True),
+    )
+
+    def __init__(self, n_groups: int = 10,
+                 n_ferns_in_group: int = 20,
+                 fern_size: int = 7,
+                 kind: str = 'unary',
+                 bootstrap: bool = False,
+                 n_jobs: Optional[int] = None,
+                 random_state: Optional[int] = None,
+                 kernel_size: Union[int, Tuple[int]] = 3,
+                 stride: Union[None, int, Tuple[int]] = None,
+                 dilation: int = 1,
+                 padding: Optional[int] = None):
+        """Initialize MGS Random Ferns Block.
+
+        Args:
+            n_groups: Number of ferns groups (like a number of estimators).
+            n_ferns_in_group: Number of ferns in a group.
+            fern_size: Number of tests in fern.
+            kind: Kind of tests ('unary' or 'binary').
+            bootstrap: Apply data bootstrap or not.
+            n_jobs: Number of threads.
+            random_state: Random state.
+
+            kernel_size: Kernel size (int or tuple).
+            stride: Stride.
+            dilation: Dilation (kernel stride).
+            padding: Padding size (see `numpy.pad`);
+                     if None padding is disabled.
+
+        """
+        super().__init__()
+        assert fern_size <= 32, 'Maximum number of tests in a fern is 32'
+        self.n_groups = n_groups
+        self.n_ferns_in_group = n_ferns_in_group
+        self.n_ferns = n_ferns_in_group * n_groups
+        self.fern_size = fern_size
+        self.kind = kind
+        self.n_buckets = 2 ** fern_size
+        self.bootstrap = bootstrap
+        self.n_jobs = n_jobs
+        self.random_state = random_state
+        self.params = _ConvolutionParams(
+            kernel_size=kernel_size,
+            stride=stride,
+            dilation=dilation,
+            padding=padding,
+        )
+        self.helper_ = _ConvolutionHelper(self.params)
+        self.pooling_indices_ = None
+
+    def _classifier_init(self, y):
+        check_classification_targets(y)
+
+        self.classes_, y_encoded = jnp.unique(y, return_inverse=True)
+        self.n_classes_ = len(self.classes_)
+        y = y_encoded
+        return y
+
+    def _get_flattened_window_size(self, X):
+        return reduce(
+            mul,
+            self.helper_.check_kernel_size(n_spatial_dims=(X.ndim - 2)),
+            1
+        )
+
+    def _make_ferns(self, X, prng_key):
+        n_channels = X.shape[1]
+        if self.kind == 'unary':
+            return make_window_unary_ferns(
+                X,
+                n_channels=n_channels,
+                window_size=self._get_flattened_window_size(X),
+                n_ferns=self.n_ferns,
+                fern_size=self.fern_size,
+                key=prng_key
+            )
+        elif self.kind == 'binary':
+            return make_window_binary_ferns(
+                n_channels=n_channels,
+                window_size=self._get_flattened_window_size(X),
+                n_ferns=self.n_ferns,
+                fern_size=self.fern_size,
+                key=prng_key
+            )
+        else:
+            raise ValueError(f'Wrong kind: {self.kind!r}')
+
+    def _apply_ferns(self, xs, ferns):
+        if self.params.padding is not None:
+            xs = self.helper_.pad(xs)
+        pooling_indices = self.__prepare_pooling_indices(xs.shape)
+        n_channels = xs.shape[1]
+        raveled_xs = xs.reshape((xs.shape[0], -1))
+        raveled_pooling_indices = jnp.ravel_multi_index(pooling_indices.full_index_tuple, xs.shape[1:])
+        if self.kind == 'unary':
+            return apply_window_unary_ferns(
+                 raveled_xs,
+                 raveled_pooling_indices,
+                 n_channels,
+                 pooling_indices.n_corners,
+                 pooling_indices.n_kernel_points,
+                 pooling_indices.pooled_shape,
+                 *ferns
+            )
+        elif self.kind == 'binary':
+            return apply_window_binary_ferns(
+                 raveled_xs,
+                 raveled_pooling_indices,
+                 n_channels,
+                 pooling_indices.n_corners,
+                 pooling_indices.n_kernel_points,
+                 pooling_indices.pooled_shape,
+                 *ferns
+            )
+        else:
+            raise ValueError(f'Wrong kind: {self.kind!r}')
+
+    def __prepare_pooling_indices(self, xs_shape):
+        if self.pooling_indices_ is not None and xs_shape == self.pooling_indices_.xs_shape:
+            return self.pooling_indices_
+
+        self.pooling_indices_ = self.helper_.prepare_pooling_indices(xs_shape)
+        return self.pooling_indices_
+
+    def _parallel_calc_bucket_stats(self, bucket_indices, y, group_data_indices):
+        bucket_stats = Parallel(n_jobs=self.n_jobs, prefer='threads')(
+            delayed(calculate_bucket_stats)(
+                bucket_indices[
+                    data_ids,
+                    slice(i * self.n_ferns_in_group, (i + 1) * self.n_ferns_in_group)
+                ],
+                self.n_buckets,
+                y[data_ids],
+                n_classes=self.n_classes_,
+            )
+            for i, data_ids in enumerate(group_data_indices)
+        )
+        bucket_stats = jnp.concatenate(bucket_stats, axis=1)
+        return bucket_stats
+
+    def fit(self, inputs: BlockInputData) -> 'MGSRandomFernsBlock':
+        """Fit the MGS Random Ferns Block.
+        The implementation is device-agnostic.
+
+        """
+        assert type(inputs['X']) == type(inputs['y'])
+        X = inputs['X'].data
+        y = inputs['y'].data
+        y = self._classifier_init(y)
+        np_rng = get_random_generator(self.random_state)
+        prng_key = random.PRNGKey(get_rand_int(np_rng))
+        prng_key, ferns_key = random.split(prng_key)
+        n_samples = X.shape[0]
+
+        ferns = self._make_ferns(X, ferns_key)
+        bucket_indices = self._apply_ferns(X, ferns)
+        # bucket_indices shape: (n_samples, n_1, ..., n_k, n_ferns)
+        n_ferns = bucket_indices.shape[-1]
+        flattened_bucket_indices = bucket_indices.reshape((-1, n_ferns))
+        spatial_size = reduce(mul, bucket_indices.shape[1:-1], 1)
+        flattened_y = jnp.tile(y[:, np.newaxis], (1, spatial_size)).reshape((-1,))
+
+        if not self.bootstrap:
+            group_data_indices = [slice(None, None) for _ in range(self.n_groups)]
+        else:
+            keys = random.split(prng_key, self.n_groups)
+            group_data_indices = [
+                random.choice(keys[i], n_samples, shape=(n_samples,), replace=True)
+                for i in range(self.n_groups)
+            ]
+
+        if self.n_jobs is None and not self.bootstrap:
+            bucket_stats = calculate_bucket_stats(
+                flattened_bucket_indices,
+                self.n_buckets,
+                flattened_y,
+                n_classes=self.n_classes_
+            )
+        else:
+            bucket_stats = self._parallel_calc_bucket_stats(
+                flattened_bucket_indices,
+                flattened_y,
+                group_data_indices
+            )
+
+        _classes, counts = jnp.unique(y, return_counts=True)
+        self.prior_ = counts / counts.sum()
+        self.ferns_ = ferns
+        self.bucket_stats_ = bucket_stats
+        return self
+
+    def _predict_proba(self, X):
+        group_preds = []
+        for group_indices in jnp.split(jnp.arange(self.n_ferns), self.n_groups):
+            prediction_bucket_indices = self._apply_ferns(X, [f[group_indices] for f in self.ferns_])
+            n_ferns = prediction_bucket_indices.shape[-1]
+            flattened_bucket_indices = prediction_bucket_indices.reshape((-1, n_ferns))
+            spatial_dims = prediction_bucket_indices.shape[1:-1]
+            probas = predict_proba(
+                flattened_bucket_indices,
+                self.bucket_stats_[:, group_indices],
+                prior=self.prior_
+            )
+            group_preds.append(
+                probas.reshape((-1, *spatial_dims, probas.shape[-1]))
+            )
+        preds = jnp.stack(group_preds, axis=0).mean(axis=0)
+        return preds
+
+    def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        X = inputs['X'].data
+
+        result = self._predict_proba(X)
+        if type(inputs['X']) == CPUData:
+            return {'probas': CPUData(np.asarray(result))}
+        elif type(inputs['X']) == GPUData:
+            return {'probas': GPUData(result)}
+        else:
+            raise NotImplementedError(f'Not implemented for input type: {type(inputs["X"])!r}')

--- a/bosk/block/zoo/models/classification/mgs_ferns.py
+++ b/bosk/block/zoo/models/classification/mgs_ferns.py
@@ -245,7 +245,8 @@ class MGSRandomFernsBlock(BaseBlock):
         ATTRS = (
             'n_groups', 'n_ferns_in_group', 'n_ferns', 'fern_size',
             'kind', 'n_buckets', 'bootstrap', 'n_jobs', 'random_state',
-            'n_classes_', 'params', 'helper_'
+            'n_classes_', 'params', 'helper_',
+            'slots',  # BaseBlock attribute
         )
         state = {
             k: getattr(self, k)

--- a/bosk/block/zoo/multi_grained_scanning/_convolution_helpers.py
+++ b/bosk/block/zoo/multi_grained_scanning/_convolution_helpers.py
@@ -114,6 +114,7 @@ class _ConvolutionHelper:
             Tuple (kernel size, kernel indices).
 
         """
+        assert n_spatial_dims > 0, 'Number of spatial dimensions should be at least 1'
         kernel_size = self.check_kernel_size(n_spatial_dims)
         kernel_ids = np.stack(np.meshgrid(*[np.arange(k) for k in kernel_size], indexing='ij'), axis=0)
         # kernel_ids shape: (n_spatial_dims, k_1, ..., k_nsd)

--- a/tests/pipelines/nd_classifier_test.py
+++ b/tests/pipelines/nd_classifier_test.py
@@ -58,7 +58,16 @@ class NDimensionalClassifier2DTest(BPT):
         pooled = b.Flatten()(X=pooled)
         rf_1 = b.RFC(random_state=self.random_state)(X=pooled, y=y)
         et_1 = b.ETC(random_state=self.random_state)(X=pooled, y=y)
-        concat_1 = b.Concat(['ms', 'rf_1', 'et_1'])(ms=pooled, rf_1=rf_1, et_1=et_1)
+        ferns_1 = b.RandomFerns(
+            n_groups=5,
+            n_ferns_in_group=5,
+            fern_size=5,
+            kind='binary',
+            bootstrap=True,
+            n_jobs=None,
+            random_state=self.random_state
+        )(X=pooled, y=y)
+        concat_1 = b.Concat(['ms', 'rf_1', 'et_1', 'ferns_1'])(ms=pooled, rf_1=rf_1, et_1=et_1, ferns_1=ferns_1)
         rf_2 = b.RFC(random_state=self.random_state)(X=concat_1, y=y)
         et_2 = b.ETC(random_state=self.random_state)(X=concat_1, y=y)
         concat_2 = b.Concat(['ms', 'rf_2', 'et_2'])(ms=pooled, rf_2=rf_2, et_2=et_2)

--- a/tests/pipelines/nd_classifier_test.py
+++ b/tests/pipelines/nd_classifier_test.py
@@ -1,0 +1,95 @@
+from sklearn.datasets import load_iris, load_digits
+from sklearn.ensemble import (
+    RandomForestClassifier,
+    ExtraTreesClassifier,
+)
+
+from bosk.data import Data, CPUData
+from bosk.pipeline.builder.functional import FunctionalPipelineBuilder
+from bosk.block.zoo.multi_grained_scanning import \
+    (MultiGrainedScanning1DBlock, MultiGrainedScanning2DBlock)
+from .base import BasePipelineTest as BPT
+from typing import Dict, Optional, Sequence, Tuple
+import logging
+
+
+def log_shape(inp):
+    logging.info('Shape: %s', inp['X'].data.shape)
+
+
+class NDimensionalClassifier2DTest(BPT):
+
+    random_state: int = 42
+    n_trees: int = 13
+
+    def _get_pipeline(self):
+        b = FunctionalPipelineBuilder()
+        X, y = b.Input()(), b.TargetInput()()
+        X = b.Reshape((-1, 1, 8, 8))(X=X)
+
+        ms = b.MGSRandomFerns(
+            n_groups=5,
+            n_ferns_in_group=5,
+            fern_size=5,
+            kind='binary',
+            bootstrap=True,
+            n_jobs=-1,
+            random_state=12345,
+            kernel_size=4,
+            stride=4,
+            dilation=1,
+            padding=None
+        )(X=X, y=y)
+        printer = b.FitLambda(
+            function=log_shape,
+            inputs=['X']
+        )(X=ms)
+        # downsample
+        pooled = b.Pooling(
+            kernel_size=2,
+            stride=None,
+            dilation=1,
+            aggregation='max',
+        )(X=printer)
+        pooled = b.FitLambda(
+            function=log_shape,
+            inputs=['X']
+        )(X=pooled)
+        pooled = b.Flatten()(X=pooled)
+        rf_1 = b.RFC(random_state=self.random_state)(X=pooled, y=y)
+        et_1 = b.ETC(random_state=self.random_state)(X=pooled, y=y)
+        concat_1 = b.Concat(['ms', 'rf_1', 'et_1'])(ms=pooled, rf_1=rf_1, et_1=et_1)
+        rf_2 = b.RFC(random_state=self.random_state)(X=concat_1, y=y)
+        et_2 = b.ETC(random_state=self.random_state)(X=concat_1, y=y)
+        concat_2 = b.Concat(['ms', 'rf_2', 'et_2'])(ms=pooled, rf_2=rf_2, et_2=et_2)
+        rf_3 = b.RFC(random_state=self.random_state)(X=concat_2, y=y)
+        et_3 = b.ETC(random_state=self.random_state)(X=concat_2, y=y)
+        stack_3 = b.Stack(['rf_3', 'et_3'], axis=1)(rf_3=rf_3, et_3=et_3)
+        average_3 = b.Average(axis=1)(X=stack_3)
+        argmax_3 = b.Argmax(axis=1)(X=average_3)
+        #
+        rf_1_roc_auc = b.RocAucMultiLabel()(gt_y=y, pred_probas=rf_1)
+        roc_auc = b.RocAucMultiLabel()(gt_y=y, pred_probas=average_3)
+        return b.build({'X': X, 'y': y},
+                    {'probas': average_3, 'rf_1_roc-auc': rf_1_roc_auc,
+                        'roc-auc': roc_auc, 'labels': argmax_3})
+
+    def make_dataset(self):
+        digits = load_digits()
+        self.x, self.y = CPUData(digits.data), CPUData(digits.target)
+
+    def get_fit_data(self) -> Dict[str, Data]:
+        if not hasattr(self, 'x'):
+            self.make_dataset()
+        return {'X': self.x, 'y': self.y}
+
+    def get_fit_in_out(self) -> Tuple[Optional[Sequence[str]], Optional[Sequence[str]]]:
+        return ['X', 'y'], ['probas', 'rf_1_roc-auc', 'roc-auc']
+
+    def get_transform_data(self) -> Dict[str, Data]:
+        if not hasattr(self, 'x'):
+            self.make_dataset()
+        return {'X': self.x}
+
+    def get_transform_in_out(self) -> Tuple[Optional[Sequence[str]], Optional[Sequence[str]]]:
+        return ['X'], ['probas', 'labels']


### PR DESCRIPTION
Two **device-agnostic** (both CPU and GPU) models have been implemented:

- Random Ferns (`RandomFernsBlock`) – classifier for data without spatial dimensions;
- Multi-Grained Scanning Random Ferns (`MGSRandomFernsBlock`) – can be applied to data with spatial dimensions (of arbitrary shape).
