### PR TITLE
[BOSK-88] Add automatic Deep Forest construction

### DIFF
--- a/bosk/auto/__init__.py
+++ b/bosk/auto/__init__.py
@@ -1,0 +1,3 @@
+"""Automatic Deep Forest Construction module.
+"""
+

--- a/bosk/auto/builders.py
+++ b/bosk/auto/builders.py
@@ -1,0 +1,96 @@
+from collections import defaultdict
+from typing import Mapping, Optional, Type
+
+from ..executor.base import BaseExecutor
+from ..pipeline.base import BasePipeline
+from ..pipeline.connection import Connection
+from ..stages import Stage
+from ..data import BaseData
+from .growing_strategies import GrowingStrategy
+from .layers import Layer
+
+
+class SequentialPipelineBuilder:
+    def __init__(self, executor_cls: Type[BaseExecutor],
+                 growing_strategy: Optional[GrowingStrategy] = None,
+                 **inputs: Mapping[str, BaseData]):
+        super().__init__()
+        self.executor_cls = executor_cls
+        self.inputs = inputs
+        self.prev_step_inputs = None
+        self.pipelines = []
+        self.growing_strategy = growing_strategy
+        self.__growing_state = dict()
+        self.history = defaultdict(list)
+
+    def append(self, layer: Layer) -> bool:
+        if self.prev_step_inputs is None:
+            step_inputs = {k: v for k, v in self.inputs.items() if k in layer.inputs}
+        else:
+            prev_pipeline = self.pipelines[-1]
+            available_outputs = [k for k in layer.inputs if k in prev_pipeline.outputs]
+            prev_transformer = self.executor_cls(prev_pipeline, Stage.TRANSFORM, outputs=available_outputs)
+            step_inputs = prev_transformer(self.prev_step_inputs)
+        # append static inputs (e.g. 'y')
+        step_inputs = {**step_inputs}
+        step_inputs.update({
+            k: self.inputs[k]
+            for k in layer.inputs
+            if k not in step_inputs
+        })
+        pipeline, metrics = layer.fit(step_inputs)
+        self.pipelines.append(pipeline)
+        self.prev_step_inputs = step_inputs
+        if not self.growing_strategy.need_grow(pipeline, metrics, self.executor_cls, self.__growing_state):
+            self.pipelines = self.growing_strategy.trim(self.pipelines, self.__growing_state)
+            return False
+        self._log_metrics(metrics)
+        return True
+
+    def _log_metrics(self, metrics):
+        if metrics is None:
+            return
+        for k, v in metrics.items():
+            self.history[k].append(v)
+
+    def build(self, map_inputs: Mapping[str, str]):
+        """
+        Args:
+            map_inputs: Map inputs aliases that are not given to the given ones.
+
+        """
+        nodes = []
+        connections = []
+        outputs = self.pipelines[-1].outputs
+        inputs = {
+            k: v
+            for k, v in self.pipelines[0].inputs.items()
+            if k not in map_inputs  # consider only inputs that will be given
+        }
+        for alias_name, given_input_name in map_inputs.items():
+            given_block = self.pipelines[0].inputs[given_input_name].parent_block
+            given_output_slot = given_block.slots.outputs[given_block.default_output]
+            connections.append(
+                Connection(
+                    given_output_slot,
+                    self.pipelines[0].inputs[alias_name]
+                )
+            )
+
+        for i, pipeline in enumerate(self.pipelines):
+            nodes.extend(pipeline.nodes)
+            connections.extend(pipeline.connections)
+            if i != 0:
+                prev_pipeline = self.pipelines[i - 1]
+                for out_name, out_slot in prev_pipeline.outputs.items():
+                    if out_name in pipeline.inputs:
+                        # matching slots by names
+                        connections.append(Connection(out_slot, pipeline.inputs[out_name]))
+
+        return BasePipeline(
+            nodes=nodes,
+            connections=connections,
+            inputs=inputs,
+            outputs=outputs,
+        )
+

--- a/bosk/auto/deep_forest.py
+++ b/bosk/auto/deep_forest.py
@@ -1,0 +1,144 @@
+"""Auto Deep Forest Construction.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, Callable
+import numpy as np
+from sklearn.model_selection import StratifiedKFold
+
+from ..data import CPUData
+from ..pipeline.base import BasePipeline
+from ..executor.base import BaseExecutor
+from ..executor.recursive import RecursiveExecutor
+from ..utility import get_rand_int, get_random_generator
+from ..block.zoo.models.classification.classification_models import ETCBlock, RFCBlock
+
+from .metrics import MetricsEvaluator
+from .growing_strategies import GrowingStrategy, DefaultGrowingStrategy, EarlyStoppingCV
+from .builders import SequentialPipelineBuilder
+from .layers import Layer, StackingLayer
+from .validation import (
+    BasePipelineModelValidator,
+    CVPipelineModelValidator,
+    DumbPipelineModelValidator,
+    TrainSetPipelineModelValidator,
+)
+
+
+DEFAULT_MAKE_METRICS = lambda: MetricsEvaluator(['f1', 'roc_auc'])
+DEFAULT_EXECUTOR_CLS = RecursiveExecutor
+
+
+class BaseAutoDeepForestConstructor(ABC):
+    """Base Auto Deep Forest Construction Algorithm.
+
+    Sequentially constructs a pipeline using given data set.
+    Construction is splitted into *steps*, where each step is subdivided into
+    *iterations*:
+
+        - At different *steps* the algorithm makes principally different blocks;
+        - At different *iterations* the algorithm generates layers of the same structure.
+
+    """
+    def __init__(self, executor_cls: BaseExecutor,
+                 max_iter: int = 10,
+                 cv: Optional[int] = 5,
+                 make_metrics: Optional[Callable[[], MetricsEvaluator]] = None,
+                 growing_strategy: Optional[GrowingStrategy] = None,
+                 random_state: Optional[int] = None):
+        self.executor_cls = executor_cls or DEFAULT_EXECUTOR_CLS
+        self.max_iter = max_iter
+        self.cv = cv
+        self.make_metrics = make_metrics or DEFAULT_MAKE_METRICS
+        if growing_strategy is None:
+            if cv is None:
+                growing_strategy = DefaultGrowingStrategy()
+            else:
+                growing_strategy = EarlyStoppingCV()
+        self.growing_strategy = growing_strategy
+        self.random_state = random_state
+
+    @property
+    @abstractmethod
+    def n_steps(self) -> int:
+        """Number of implemented steps.
+
+        The steps with number < `n_steps` will be passed to `make_step_layer`.
+        """
+
+    @abstractmethod
+    def make_step_layer(self, step: int, iteration: int,
+                        X: np.ndarray, y: np.ndarray,
+                        validator: BasePipelineModelValidator,
+                        rng: np.random.RandomState) -> Optional[Layer]:
+        ...
+
+    def construct(self, X: np.ndarray, y: np.ndarray) -> BasePipeline:
+        rng = get_random_generator(self.random_state)
+        X = CPUData(X)
+        y = CPUData(y)
+        # prepare the validator
+        if self.cv is None:
+            validator = DumbPipelineModelValidator(None, self.make_metrics)
+        elif self.cv == 1:
+            validator = TrainSetPipelineModelValidator(None, self.make_metrics)
+        else:
+            validator = CVPipelineModelValidator(
+                StratifiedKFold(n_splits=self.cv, shuffle=True, random_state=12345),
+                self.make_metrics,
+            )
+        # prepare the make
+        maker = SequentialPipelineBuilder(
+            self.executor_cls,
+            growing_strategy=self.growing_strategy,
+            X=X,
+            X_original=X,
+            y=y
+        )
+        for step in range(self.n_steps):
+            for i in range(self.max_iter):
+                next_layer = self.make_step_layer(step, i, X.data, y.data, validator, rng)
+                if next_layer is None:
+                    break
+                need_continue = maker.append(next_layer)
+                if not need_continue:
+                    break
+
+        pipeline = maker.build({'X_original': 'X'})
+        self.history = maker.history
+        return pipeline
+
+
+class ClassicalDeepForestConstructor(BaseAutoDeepForestConstructor):
+    """Classical Deep Forest iteratively builds layers consisting of different
+    Random Forests and Extremely Randomized Trees Classifiers.
+
+    Attributes:
+        n_steps: Number of steps. The Classical Deep Forest has just one step.
+        rf_params: Parameters of tree ensembles (Random Forests, Extra Trees).
+
+    """
+    n_steps = 1
+
+    def __init__(self, executor_cls: BaseExecutor, rf_params: Optional[dict] = None,
+                 max_iter: int = 10,
+                 cv: Optional[int] = 5,
+                 make_metrics: Optional[Callable[[], MetricsEvaluator]] = None,
+                 growing_strategy: Optional[GrowingStrategy] = None,
+                 random_state: Optional[int] = None):
+        super().__init__(executor_cls, max_iter, cv, make_metrics, growing_strategy, random_state)
+        if rf_params is None:
+            rf_params = dict()
+        self.rf_params = rf_params
+
+    def make_step_layer(self, step: int, iteration: int,
+                        X: np.ndarray, y: np.ndarray,
+                        validator: BasePipelineModelValidator,
+                        rng: np.random.RandomState):
+        p = self.rf_params
+        return StackingLayer(
+            make_blocks=lambda: [RFCBlock(**p), ETCBlock(**p), RFCBlock(**p), ETCBlock(**p)],
+            executor_cls=self.executor_cls,
+            validator=validator,
+            random_state=get_rand_int(rng)
+        )

--- a/bosk/auto/deep_forest.py
+++ b/bosk/auto/deep_forest.py
@@ -105,7 +105,7 @@ class BaseAutoDeepForestConstructor(ABC):
                 if not need_continue:
                     break
 
-        pipeline = maker.build({'X_original': 'X'})
+        pipeline = maker.build(dict())
         self.history = maker.history
         return pipeline
 
@@ -161,6 +161,7 @@ class ClassicalDeepForestConstructor(BaseAutoDeepForestConstructor):
                         rng: np.random.RandomState):
         return self.LAYER_CLS(
             make_blocks=lambda: _make_base_df_blocks(self.rf_params, self.layer_width),
+            layer_name=f'{self.LAYER_CLS.__name__}({step=}, {iteration=})',
             executor_cls=self.executor_cls,
             validator=validator,
             random_state=get_rand_int(rng)

--- a/bosk/auto/growing_strategies.py
+++ b/bosk/auto/growing_strategies.py
@@ -1,0 +1,98 @@
+from abc import ABC, abstractmethod
+from typing import Callable, List, Literal, Mapping, Sequence, Type
+
+from ..pipeline.base import BasePipeline
+from ..data import BaseData
+from ..stages import Stage
+from ..executor.base import BaseExecutor
+from .metrics import MetricsEvaluator
+
+
+class GrowingStrategy(ABC):
+    @abstractmethod
+    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
+        ...
+
+    def trim(self, pipelines: Sequence[BasePipeline], growing_state: dict):
+        return pipelines
+
+
+class DefaultGrowingStrategy(GrowingStrategy):
+    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
+        True
+
+
+class EarlyStoppingCV(GrowingStrategy):
+    def __init__(self, mode: Literal['any'] | Literal['all'] = 'all', patience: int = 1):
+        self.mode = mode
+        self.patience = patience
+
+    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
+        assert metrics is not None, 'Please, calculate CV metrics first'
+        if 'best_metrics' not in growing_state:
+            growing_state['best_metrics'] = metrics
+            growing_state['count'] = 0
+            return True
+        MODES = {
+            'any': any,
+            'all': all
+        }
+        best_metrics = growing_state['best_metrics']
+        # check if new metrics are lower than previous
+        new_metrics_worse = MODES[self.mode](
+            metrics[metric_name] <= best_metrics[metric_name]
+            for metric_name in metrics.keys()
+        )
+        # update the best metrics
+        growing_state['best_metrics'] = {
+            metric_name: max(metrics[metric_name], best_metrics[metric_name])
+            for metric_name in metrics.keys()
+        }
+        if new_metrics_worse:
+            growing_state['count'] += 1
+            if growing_state['count'] > self.patience:
+                return False
+        else:
+            growing_state['count'] = 0
+        return True
+
+    def trim(self, pipelines: List[BasePipeline], growing_state: dict):
+        """Trim the last `count` pipelines.
+        """
+        count = growing_state['count']
+        if count > 0:
+            return pipelines[:-count]
+        return pipelines
+
+
+class EarlyStoppingVal(EarlyStoppingCV):
+    def __init__(self, data: Mapping[str, BaseData], make_metrics_eval: Callable[[], MetricsEvaluator],
+                 **early_stopping_params: dict):
+        super().__init__(**early_stopping_params)
+        self.initial_data = {k: v for k, v in data.items() if k != 'y'}
+        self.y = data['y']
+        self.make_metrics_eval = make_metrics_eval
+
+    def need_grow(self, pipeline, metrics, executor_cls: Type[BaseExecutor], growing_state: dict) -> bool:
+        if 'metrics' not in growing_state:
+            growing_state['current_data'] = self.initial_data
+        transformer = executor_cls(pipeline, Stage.TRANSFORM)
+        current_input = {
+            k: v
+            for k, v in growing_state['current_data'].items()
+            if k != 'proba'
+        }
+        predictions = transformer(current_input)
+        growing_state['current_data'] = predictions
+        metrics_eval = self.make_metrics_eval()
+        metrics_eval.append_eval(self.y.data, predictions['proba'].data)
+        val_metrics = metrics_eval.average()
+        return super().need_grow(pipeline, val_metrics, executor_cls, growing_state)
+
+    def trim(self, pipelines: List[BasePipeline], growing_state: dict):
+        """Trim the last `count` pipelines.
+        """
+        count = growing_state['count']
+        if count > 0:
+            return pipelines[:-count]
+        return pipelines

--- a/bosk/auto/layers.py
+++ b/bosk/auto/layers.py
@@ -151,7 +151,7 @@ class MGSRFLayer(Layer):
             #     dilation=1,
             #     aggregation='max',
             # )(X=concat_ms)
-            pooled=concat_ms  # no pooling required, since MultiGrainedScanningND reduced dimensions
+            pooled = concat_ms  # no pooling required, since MultiGrainedScanningND reduced dimensions
             # for the next iteration
             reshaped_ = pooled
             current_spatial_dims = conv_helper.get_pooled_shape(
@@ -160,6 +160,7 @@ class MGSRFLayer(Layer):
                 stride
             )
 
+        pooled = b.GlobalAveragePooling()(X=pooled)
         pooled = b.Flatten()(X=pooled)
         proba = b.ETC(random_state=get_rand_int(rng))(X=pooled, y=y_)
         embedding_output = b.Output('X')(pooled)

--- a/bosk/auto/layers.py
+++ b/bosk/auto/layers.py
@@ -1,0 +1,288 @@
+import numpy as np
+from sklearn.model_selection import StratifiedKFold
+from abc import ABC, abstractmethod
+from typing import Callable, List, Optional, Sequence, Tuple, Mapping, Type
+
+from ..stages import Stage
+from ..utility import get_rand_int, get_random_generator
+from ..visitor.group import ModifyGroupVisitor
+from ..pipeline.builder.functional import FunctionalPipelineBuilder
+from ..block.zoo.models.classification.classification_models import RFCBlock, ETCBlock
+from ..block.base import BaseBlock, BlockOutputData
+from ..block.slot import BlockGroup
+from ..data import BaseData, CPUData
+from ..executor.base import BaseExecutor, DefaultBlockExecutor, InputSlotToDataMapping
+from ..pipeline.base import BasePipeline
+from .validation import CVPipelineModelValidator
+from .metrics import MetricsResults
+
+
+
+class Layer(ABC):
+    def __init__(self, executor_cls: Type[BaseExecutor],
+                 validator: CVPipelineModelValidator,
+                 layer_name: str = 'forests_layer',
+                 random_state: Optional[int] = None):
+        self.executor_cls = executor_cls
+        self.validator = validator
+        self.layer_name = layer_name
+        self.random_state = random_state
+
+    @property
+    @abstractmethod
+    def inputs(self):
+        ...
+
+    @abstractmethod
+    def fit(self, inputs: Mapping[str, BaseData]) -> Tuple[BasePipeline, MetricsResults]:
+        ...
+
+    def calc_metrics(self, data: Mapping[str, CPUData], pipeline: BasePipeline,
+                       output: str, fit_outputs: List[str]) -> Mapping[str, float]:
+        fitter = self.executor_cls(pipeline, Stage.FIT, outputs=[output, *fit_outputs])
+        transformer = self.executor_cls(pipeline, Stage.TRANSFORM)
+        return self.validator.calc_metrics(data, fitter, transformer, output)
+
+
+class MGSLayer(Layer):
+    inputs = ['X', 'y']
+
+    def __init__(self, input_shape: Tuple[int], **kwargs):
+        super().__init__(**kwargs)
+        self.input_shape = input_shape
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        y_ = b.Input('y')()
+        reshaped_ = b.Reshape((-1, *self.input_shape))(x_)
+        ms = b.MGSRandomFerns(
+            n_groups=20,
+            n_ferns_in_group=5,
+            fern_size=15,
+            kind='unary',
+            bootstrap=False,
+            n_jobs=-1,
+            random_state=get_rand_int(rng),
+            kernel_size=3,
+            stride=3,
+            dilation=1,
+            padding=None
+        )(X=reshaped_, y=y_)
+        pooled = b.Pooling(
+            kernel_size=2,
+            stride=None,
+            dilation=1,
+            aggregation='max',
+        )(X=ms)
+        pooled = b.Flatten()(X=pooled)
+        proba = b.RandomFerns(
+            n_groups=5,
+            n_ferns_in_group=5,
+            fern_size=5,
+            kind='unary',
+            bootstrap=True,
+            n_jobs=-1,
+            random_state=get_rand_int(rng),
+        )(X=pooled, y=y_)
+        embedding_output = b.Output('X')(pooled)
+        proba_output = b.Output('proba')(proba)  # used only for validation
+        b.Output('X_original')(embedding_output)
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba'])
+            fitter(data)
+        return pipeline, metric_values
+
+
+class MGSRFLayer(Layer):
+    inputs = ['X', 'y']
+
+    def __init__(self, input_shape: Tuple[int], **kwargs):
+        super().__init__(**kwargs)
+        self.input_shape = input_shape
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        y_ = b.Input('y')()
+        reshaped_ = b.Reshape((-1, *self.input_shape))(x_)
+        ms = b.MultiGrainedScanningND(
+            model=ETCBlock(random_state=get_rand_int(rng)),
+            kernel_size=4,
+            stride=2,
+            dilation=1,
+            padding=None
+        )(X=reshaped_, y=y_)
+        pooled = b.Pooling(
+            kernel_size=2,
+            stride=None,
+            dilation=1,
+            aggregation='max',
+        )(X=ms)
+        pooled = b.Flatten()(X=pooled)
+        proba = b.ETC(random_state=get_rand_int(rng))(X=pooled, y=y_)
+        # embedding_output = b.Output('X')(b.Stack(['pooled', 'proba'])(pooled=pooled, proba=proba))
+        embedding_output = b.Output('X')(pooled)
+        proba_output = b.Output('proba')(proba)  # used only for validation
+        b.Output('X_original')(embedding_output)
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba'])
+            fitter(data)
+        return pipeline, metric_values
+
+
+
+class ForestsLayer(Layer):
+    inputs = ['X', 'X_original', 'y']
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        # forests layer leverages CPU algorithms
+        data = {
+            k: v.to_cpu()
+            for k, v in data.items()
+        }
+
+        # build a fixed pipeline
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        x_original_ = b.Input('X_original')()
+        y_ = b.TargetInput('y')()
+
+        rf_ = b.RFC(random_state=get_rand_int(rng))(X=x_, y=y_)
+        et_ = b.ETC(random_state=get_rand_int(rng))(X=x_, y=y_)
+        embedding_ = b.Concat(['X_original', 'rf', 'et'], axis=1)(X_original=x_original_, rf=rf_, et=et_)
+        embedding_output = b.Output('X')(embedding_)
+        original_output = b.Output('X_original')(x_original_)
+
+        proba_ = b.Average(axis=-1)(b.Stack(['rf', 'et'], axis=-1)(rf=rf_, et=et_))
+        proba_output = b.Output('proba')(proba_)
+
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba', 'X'])
+            fitter(data)
+        return pipeline, metric_values
+
+
+class FitBlacklistBlockExecutor(DefaultBlockExecutor):
+    """Block executor that does not call `fit` method for the blocks that are in the black list.
+
+    It is used to be able to manually fit some blocks of the pipeline and avoid overriding of the state
+    when the whole pipeline is fitted.
+    """
+    def __init__(self, blacklist: Sequence[BaseBlock]) -> None:
+        super().__init__()
+        self.blacklist = set(blacklist)
+
+    def execute_block(self, stage: Stage, block: BaseBlock,
+                        block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        if block in self.blacklist:
+            # avoid block fitting
+            filtered_block_input_mapping = {
+                slot.meta.name: values
+                for slot, values in block_input_mapping.items()
+                if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit)
+            }
+            return block.wrap(block.transform(filtered_block_input_mapping))
+        return super().execute_block(stage, block, block_input_mapping)
+
+
+class StackingLayer(Layer):
+    inputs = ['X', 'X_original', 'y']
+
+    def __init__(self, make_blocks: Callable[[], Sequence[BaseBlock]],
+                 executor_cls: Type[BaseExecutor],
+                 validator: CVPipelineModelValidator,
+                 layer_name: str = 'stacking_layer',
+                 random_state: Optional[int] = None):
+        super().__init__(
+            executor_cls=executor_cls,
+            validator=validator,
+            layer_name=layer_name,
+            random_state=random_state,
+        )
+        self.make_blocks = make_blocks
+
+    def __custom_cross_validate(self, data: Mapping[str, BaseData], pipeline: BasePipeline,
+                       blocks: List[BaseBlock], rng: np.random.RandomState) -> Mapping[str, float]:
+        fitter = self._make_fitter(pipeline, blocks, rng)
+        transformer = self.executor_cls(pipeline, Stage.TRANSFORM)
+        return self.validator.calc_metrics(data, fitter, transformer, 'proba')
+
+    def _make_fitter(self, pipeline: BasePipeline, blocks: List[BaseBlock], rng: np.random.RandomState):
+        new_rng = get_random_generator(get_rand_int(rng))
+        basic_fitter = self.executor_cls(pipeline, Stage.FIT, block_executor=FitBlacklistBlockExecutor(blocks))
+        def _fit_fn(inputs: Mapping[str, CPUData]):
+            kfold = StratifiedKFold(n_splits=len(blocks), shuffle=True, random_state=get_rand_int(new_rng))
+            inp_X, inp_y = inputs['X'].data, inputs['y'].data
+            split_gen = kfold.split(inp_X, inp_y)
+            for i, (block_train_idx, _rest_idx) in enumerate(split_gen):
+                blocks[i].fit({'X': inp_X[block_train_idx], 'y': inp_y[block_train_idx]})
+            basic_fitter(inputs)
+            return None
+        return _fit_fn
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        # forests layer leverages CPU algorithms
+        data = {
+            k: v.to_cpu()
+            for k, v in data.items()
+        }
+
+        # build a fixed pipeline
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        x_original_ = b.Input('X_original')()
+        y_ = b.TargetInput('y')()
+
+        blocks = self.make_blocks()
+        block_wrappers = [
+            b.wrap(block)(X=x_, y=y_)
+            for block in blocks
+        ]
+        # set random states
+        for bw in block_wrappers:
+            bw.block.set_random_state(get_rand_int(rng))
+        block_names = [f'block_{i}' for i in range(len(block_wrappers))]
+        named_block_wrappers = dict(zip(block_names, block_wrappers))
+        # concatenate embeddings with original feature vector
+        embedding_ = b.Concat(['X_original', *block_names], axis=1)(X_original=x_original_, **named_block_wrappers)
+        proba_ = b.Average(axis=-1)(b.Stack(block_names, axis=-1)(**named_block_wrappers))
+
+        # specify outputs
+        b.Output('X')(embedding_)
+        b.Output('X_original')(x_original_)
+        b.Output('proba')(proba_)
+
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        blocks = [w.block for w in block_wrappers]
+        metric_values = self.__custom_cross_validate(data, pipeline, blocks, rng)
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self._make_fitter(pipeline, blocks, rng)
+            fitter(data)
+        return pipeline, metric_values

--- a/bosk/auto/metrics.py
+++ b/bosk/auto/metrics.py
@@ -1,0 +1,33 @@
+import numpy as np
+from typing import List, Mapping
+from collections import defaultdict
+from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
+
+
+MetricsResults = Mapping[str, float]
+
+
+class MetricsEvaluator:
+    """Calculates, collects and aggregates the specified metrics.
+
+    Any metric follows the rule "the higher is better", i.e.
+    if originally metric decreases when quality increases, it is multiplied by (-1).
+    """
+    def __init__(self, names: List[str]):
+        self.names = set(names)
+        self.results = defaultdict(list)
+
+    def append_eval(self, y_true: np.ndarray, y_pred: np.ndarray):
+        pred_labels = np.argmax(y_pred, axis=1)
+        if 'roc_auc' in self.names:
+            self.results['roc_auc'].append(roc_auc_score(y_true, y_pred, multi_class='ovr'))
+        if 'f1' in self.names:
+            self.results['f1'].append(f1_score(y_true, pred_labels, average='macro'))
+        if 'accuracy' in self.names:
+            self.results['accuracy'].append(accuracy_score(y_true, pred_labels))
+
+    def average(self) -> MetricsResults:
+        return {
+            k: np.mean(v)
+            for k, v in self.results.items()
+        }

--- a/bosk/auto/validation.py
+++ b/bosk/auto/validation.py
@@ -1,0 +1,84 @@
+from abc import ABC, abstractmethod
+from typing import Callable, List, Optional, Mapping
+from sklearn.model_selection import BaseCrossValidator
+
+from ..data import CPUData
+from .metrics import MetricsEvaluator
+
+
+class BasePipelineModelValidator(ABC):
+    """Pipeline model validator calculates metrics given dataset and fit, transform methods.
+    """
+    @abstractmethod
+    def __init__(self, cv: Optional[BaseCrossValidator],
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        ...
+
+    @abstractmethod
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        ...
+
+
+class CVPipelineModelValidator(BasePipelineModelValidator):
+    need_refit = True
+
+    def __init__(self, cv: BaseCrossValidator,
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        self.cv = cv
+        self.metrics_cls = metrics_cls
+
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        metrics = self.metrics_cls()
+        for train_idx, val_idx in self.cv.split(data['X'].data, data['y'].data):
+            train_data = {
+                k: CPUData(v.data[train_idx])
+                for k, v in data.items()
+            }
+            fitter(train_data)
+            val_data = {
+                k: CPUData(v.data[val_idx])
+                for k, v in data.items()
+            }
+            preds_val = transformer({k: v for k, v in val_data.items() if k != 'y'})[output].data
+            metrics.append_eval(val_data['y'].data, preds_val.data)
+        return metrics.average()
+
+
+class DumbPipelineModelValidator(BasePipelineModelValidator):
+    need_refit = True
+
+    def __init__(self, cv: BaseCrossValidator,
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        self.cv = cv
+        self.metrics_cls = metrics_cls
+
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        return None
+
+
+class TrainSetPipelineModelValidator(BasePipelineModelValidator):
+    need_refit = False
+
+    def __init__(self, cv: BaseCrossValidator,
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        self.cv = cv
+        self.metrics_cls = metrics_cls
+
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        metrics = self.metrics_cls()
+        fitter(data)
+        preds = transformer({k: v for k, v in data.items() if k != 'y'})[output].data
+        metrics.append_eval(data['y'].data, preds)
+        return metrics.average()

--- a/bosk/block/base.py
+++ b/bosk/block/base.py
@@ -126,6 +126,20 @@ class BaseBlock(ABC):
         random generator or integer value.
         """
 
+    @property
+    def default_output(self) -> Optional[str]:
+        """Get default output name.
+
+        If the block has a single output, it will be used as a default.
+        Otherwise, the block can override this property to set a specific default output.
+        If the block can't have a single default output (its outputs have equal importance),
+        this method should return `None`.
+        """
+        if len(self.meta.outputs) == 1:
+            return next(iter(self.meta.outputs.keys()))
+        else:
+            return None
+
 
 class BaseInputBlock(BaseBlock, metaclass=ABCMeta):
     """Base input block. It is guaranteed that is has a single input and some name.

--- a/bosk/block/functional.py
+++ b/bosk/block/functional.py
@@ -86,10 +86,10 @@ class FunctionalBlockWrapper:
 
         """
         if self.output_name is None:
-            if len(self.block.slots.outputs) == 1:
-                return list(self.block.slots.outputs.values())[0]
+            if self.block.default_output is None:
+                raise RuntimeError('Block has more than one output and the default is not specified')
             else:
-                raise RuntimeError('Block has more than one output')
+                return self.block.slots.outputs[self.block.default_output]
         return self.block.slots.outputs[self.output_name]
 
     def __getitem__(self, output_name: str) -> 'FunctionalBlockWrapper':

--- a/bosk/block/slot.py
+++ b/bosk/block/slot.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import List, Mapping, TypeVar
+from dataclasses import dataclass, field
+from typing import List, Mapping, Set, TypeVar
 from ..stages import Stages
 
 
@@ -50,7 +50,7 @@ class BaseSlot:
 
     def __hash__(self) -> int:
         return id(self)
-    
+
     def __repr__(self) -> str:
         return self.meta.name
 
@@ -112,7 +112,31 @@ def list_of_slots_meta_to_mapping(slots_meta_list: List[SlotMetaT]) -> Mapping[s
     }
 
 
+@dataclass(frozen=True)
+class BlockGroup:
+    name: str
+
+    def add(self, block: BaseBlock):
+        """Add the block to the group.
+
+        Args:
+            block: Block to add.
+
+        """
+        block.slots.groups.add(self)
+
+    def remove(self, block: BaseBlock):
+        """Remove the block from the group.
+
+        Args:
+            block: Block to remove.
+
+        """
+        block.slots.groups.remove(self)
+
+
 @dataclass
 class BlockSlots:
     inputs: Mapping[str, BlockInputSlot]
     outputs: Mapping[str, BlockOutputSlot]
+    groups: Set[BlockGroup] = field(default_factory=lambda: set())

--- a/bosk/block/slot.py
+++ b/bosk/block/slot.py
@@ -134,6 +134,9 @@ class BlockGroup:
         """
         block.slots.groups.remove(self)
 
+    def __repr__(self) -> str:
+        return self.name
+
 
 @dataclass
 class BlockSlots:

--- a/bosk/block/zoo/multi_grained_scanning/pooling.py
+++ b/bosk/block/zoo/multi_grained_scanning/pooling.py
@@ -244,7 +244,7 @@ class GlobalAveragePoolingBlock(BaseBlock):
         super().__init__()
         self.axis = axis
 
-    def _check_dims(inputs):
+    def _check_dims(self, inputs):
         assert 'X' in inputs
         assert inputs['X'].data.ndim > 2, 'Global Average Pooling supports only data with at least one spatial dimension'
 

--- a/bosk/block/zoo/multi_grained_scanning/pooling.py
+++ b/bosk/block/zoo/multi_grained_scanning/pooling.py
@@ -231,3 +231,35 @@ class PoolingBlock(BaseBlock):
         else:
             raise NotImplementedError(f'Not implemented for type {type(inputs["X"])!r}')
 
+
+class GlobalAveragePoolingBlock(BaseBlock):
+    """Global Average Pooling averages across all dimensions except sample and channels.
+
+    For example, given an input of shape `(n_samples, n_channels, n_1, ..., n_d)`,
+    the output will be of shape `(n_samples, n_channels)`.
+    """
+    meta = make_simple_meta(['X'], ['output'], execution_props=BlockExecutionProperties(cpu=True, gpu=True, plain=True))
+
+    def __init__(self, axis: int = -1):
+        super().__init__()
+        self.axis = axis
+
+    def _check_dims(inputs):
+        assert 'X' in inputs
+        assert inputs['X'].data.ndim > 2, 'Global Average Pooling supports only data with at least one spatial dimension'
+
+    def fit(self, inputs: BlockInputData) -> 'GlobalAveragePoolingBlock':
+        self._check_dims(inputs)
+        return self
+
+    def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        self._check_dims(inputs)
+        input_type = type(inputs['X'])
+        if input_type not in [CPUData, GPUData]:
+            raise TypeError("All inputs must be of type: CPUData or GPUData.")
+        spatial_axes = tuple(range(2, inputs['X'].data.ndim))
+        averaged = inputs['X'].data.mean(axis=spatial_axes)
+        if input_type == CPUData:
+            return {'output': CPUData(averaged)}
+        else:
+            return {'output': GPUData(averaged)}

--- a/bosk/block/zoo/routing/__init__.py
+++ b/bosk/block/zoo/routing/__init__.py
@@ -1,1 +1,2 @@
 from .routing import CSBlock, CSJoinBlock, CSFilterBlock
+from .cv import CVTrainIndicesBlock, SubsetTrainWrapperBlock

--- a/bosk/block/zoo/routing/cv.py
+++ b/bosk/block/zoo/routing/cv.py
@@ -1,0 +1,102 @@
+import numpy as np
+from typing import Optional
+from sklearn.model_selection import StratifiedKFold
+
+from ...base import BaseBlock
+from ....stages import Stages
+from ....data import CPUData
+from ...meta import BlockMeta, BlockExecutionProperties, InputSlotMeta, OutputSlotMeta
+
+
+class CVTrainIndicesBlock(BaseBlock):
+    """Cross-validation Training Indices Block.
+
+    Generates training indices for `size` models.
+    The block has `size` outputs, each named as a number of model: `"0", "1", ...`.
+    """
+    meta = None
+
+    def __init__(self, size: int, random_state: Optional[int]):
+        self.size = size
+        self.random_state = random_state
+        self.meta = BlockMeta(
+            inputs=[
+                InputSlotMeta(name=name, stages=Stages(fit=True, transform=False, transform_on_fit=True))
+                for name in ('X', 'y')
+            ],
+            outputs=[
+                OutputSlotMeta(name=str(i), stages=Stages(fit=True, transform=False, transform_on_fit=True))
+                for i in range(size)
+            ],
+            execution_props=BlockExecutionProperties(plain=True)
+        )
+        super().__init__()
+
+    def fit(self, inputs):
+        pass
+
+    def transform(self, inputs):
+        X = inputs['X'].data
+        y = inputs['y'].data
+        kfold = StratifiedKFold(n_splits=self.size, shuffle=True, random_state=self.random_state)
+        return {
+            str(i): CPUData(train_idx)
+            for i, (train_idx, _test_idx) in enumerate(kfold.split(X, y))
+        }
+
+
+class SubsetTrainWrapperBlock(BaseBlock):
+    """Block wrapper that fits the base block on the indices subset.
+
+    The base block may have an arbitrary number of inputs of any type,
+    but should not accept input named `"trainin_indices"`.
+
+    At FIT stage the wrapper extracts subsets of each input along the first dimension.
+
+    At TRANSFORM stage the wrapper bypasses inputs to the base block.
+
+    """
+    TRAINING_INDICES_NAME = 'training_indices'
+
+    meta = None
+
+    def __init__(self, block: BaseBlock):
+        self.meta = BlockMeta(
+            inputs=[
+                inp for inp in block.meta.inputs.values()
+            ] + [
+                InputSlotMeta(
+                    name='training_indices',
+                    stages=Stages(fit=True, transform=False, transform_on_fit=True)
+                )
+            ],
+            outputs=[
+                out for out in block.meta.outputs.values()
+            ],
+            execution_props=block.meta.execution_props
+        )
+        self.block = block
+        super().__init__()
+
+    def _exclude_training_indices(self, inputs):
+        return {
+            k: v
+            for k, v in inputs.items()
+            if k != self.TRAINING_INDICES_NAME
+        }
+
+    def fit(self, inputs):
+        ids = inputs[self.TRAINING_INDICES_NAME].data
+        block_inputs = {
+            k: v.__class__(v.data[ids])
+            for k, v in self._exclude_training_indices(inputs).items()
+        }
+        self.block.fit(block_inputs)
+        return self
+
+    def transform(self, inputs):
+        block_inputs = self._exclude_training_indices(inputs)
+        return self.block.transform(block_inputs)
+
+    def set_random_state(self, seed: Optional[int | np.random.RandomState]) -> None:
+        return self.block.set_random_state(seed)

--- a/bosk/data.py
+++ b/bosk/data.py
@@ -21,6 +21,9 @@ class BaseData:
         """Transfers data to a GPU-based representation."""
         return GPUData(self.data)
 
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} {self.data.shape!r} {self.data.dtype!r}>'
+
 
 class CPUData(BaseData):
     def __init__(self, data: Any):

--- a/bosk/executor/block.py
+++ b/bosk/executor/block.py
@@ -1,0 +1,86 @@
+from abc import ABC, abstractmethod
+from typing import Mapping, FrozenSet, Optional, Sequence
+
+from ..data import Data
+from ..stages import Stage
+from ..block.base import BaseBlock, BlockOutputData
+from ..block.slot import BlockGroup, BlockInputSlot, BaseSlot
+from ..pipeline import BasePipeline
+import warnings
+
+
+InputSlotToDataMapping = Mapping[BlockInputSlot, Data]
+"""Block input slot data mapping.
+
+It is indexed by input slots.
+"""
+
+
+class BaseBlockExecutor(ABC):
+    """Determines a block execution.
+
+    """
+
+    @abstractmethod
+    def execute_block(self, stage: Stage, block: BaseBlock,
+                      block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        """Method that executes the block.
+
+        Args:
+            stage: The execution stage.
+            block: The computational block to execute.
+            block_input_mapping: The data for the block execution.
+        """
+
+
+class DefaultBlockExecutor(BaseBlockExecutor):
+    def execute_block(self, stage: Stage,
+                      block: BaseBlock,
+                      block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        if stage == Stage.FIT:
+            block.fit({
+                slot.meta.name: values
+                for slot, values in block_input_mapping.items()
+                if slot.meta.stages.fit
+            })
+        filtered_block_input_mapping = {
+            slot.meta.name: values
+            for slot, values in block_input_mapping.items()
+            if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit)
+        }
+        return block.wrap(block.transform(filtered_block_input_mapping))
+
+
+class FitBlacklistBlockExecutor(DefaultBlockExecutor):
+    """Block executor that does not call `fit` method for the blocks that are in the black list.
+
+    It is used to be able to manually fit some blocks of the pipeline and avoid overriding of the state
+    when the whole pipeline is fitted.
+    """
+    def __init__(self, ignore_blocks: Optional[Sequence[BaseBlock]] = None,
+                 ignore_groups: Optional[Sequence[BlockGroup]] = None) -> None:
+        """Initialize the block executor.
+
+        Args:
+            ignore_blocks: List of blocks to ignore.
+            ignore_groups: List of block groups to ignore.
+                           If block belongs to at least one group from `ignore_groups`,
+                           it won't be fitted.
+
+        """
+        super().__init__()
+        self.ignore_blocks = set(ignore_blocks or [])
+        self.ignore_groups = set(ignore_groups or [])
+
+    def execute_block(self, stage: Stage, block: BaseBlock,
+                        block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        need_ignore_fit = (block in self.ignore_blocks) or (not block.slots.groups.isdisjoint(self.ignore_groups))
+        if need_ignore_fit:
+            # avoid block fitting, just apply transform
+            filtered_block_input_mapping = {
+                slot.meta.name: values
+                for slot, values in block_input_mapping.items()
+                if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit)
+            }
+            return block.wrap(block.transform(filtered_block_input_mapping))
+        return super().execute_block(stage, block, block_input_mapping)

--- a/bosk/pipeline/builder/functional.py
+++ b/bosk/pipeline/builder/functional.py
@@ -1,4 +1,4 @@
-from typing import Literal, Mapping, Union
+from typing import Literal, Mapping, Type, Union
 from ...block import BaseBlock, BaseInputBlock, BaseOutputBlock
 from ...block.functional import FunctionalBlockWrapper
 from ...block.repo import BaseBlockClassRepository, DEFAULT_BLOCK_CLASS_REPOSITORY
@@ -41,8 +41,8 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
         """
         self._nodes.append(block)
 
-    def _make_placeholder_fn(self, block: BaseBlock) -> Callable:
-        def placeholder_fn(*pfn_args, **pfn_kwargs):
+    def _make_placeholder_fn(self, block: BaseBlock) -> Callable[..., FunctionalBlockWrapper]:
+        def placeholder_fn(*pfn_args, **pfn_kwargs) -> FunctionalBlockWrapper:
             """Placeholder function.
 
             Placeholder function operates with functional block wrappers:
@@ -79,7 +79,7 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
 
         return placeholder_fn
 
-    def wrap(self, block: BaseBlock) -> Callable:
+    def wrap(self, block: BaseBlock) -> Callable[..., FunctionalBlockWrapper]:
         """Register the block in the builder and wrap it into a placeholder function.
 
         Args:
@@ -103,7 +103,7 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
         self._register_block(block)
         return self._make_placeholder_fn(block)
 
-    def _get_block_init(self, block_cls: Callable) -> Callable:
+    def _get_block_init(self, block_cls: Type[BaseBlock]) -> Callable[..., Callable[..., FunctionalBlockWrapper]]:
         """Get a new block initialization wrapper.
 
         Args:
@@ -134,7 +134,7 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
 
         return block_init
 
-    def new(self, block_cls: Callable, *args, **kwargs) -> Callable:
+    def new(self, block_cls: Type[BaseBlock], *args, **kwargs) -> Callable[..., FunctionalBlockWrapper]:
         """Make a new block wrapper of given block class.
 
         Constructs block wrapper using given block class constructor

--- a/bosk/visitor/group.py
+++ b/bosk/visitor/group.py
@@ -1,0 +1,31 @@
+"""Visitors for group modifications.
+"""
+from functools import singledispatchmethod
+from typing import Literal
+from .base import BaseVisitor
+from ..block.slot import BlockGroup
+from ..block import BaseBlock
+
+
+ModificationAction = Literal['add'] | Literal['remove']
+
+
+class ModifyGroupVisitor(BaseVisitor):
+    """Visitor for block groups modification, given a group and action.
+    """
+    def __init__(self, action: ModificationAction, group: BlockGroup):
+        self.action = action
+        self.group = group
+
+    @singledispatchmethod
+    def visit(self, obj):
+        pass  # ignore extra entities
+
+    @visit.register
+    def _(self, block: BaseBlock):
+        if self.action == 'add':
+            self.group.add(block)
+        elif self.action == 'remove':
+            self.group.remove(block)
+        else:
+            raise NotImplementedError()

--- a/examples/deep_forests/automatic/automatic.py
+++ b/examples/deep_forests/automatic/automatic.py
@@ -1,551 +1,39 @@
-from collections import defaultdict
-from functools import singledispatchmethod
-from bosk.block.base import BaseBlock, BaseInputBlock, BlockOutputData
-from bosk.block.functional import FunctionalBlockWrapper
-from bosk.block.slot import BlockGroup, BlockInputSlot, BlockOutputSlot
-from bosk.data import BaseData, CPUData
-from bosk.executor.base import BaseBlockExecutor, BaseExecutor, DefaultBlockExecutor, InputSlotToDataMapping
-from bosk.executor.recursive import RecursiveExecutor
-from bosk.pipeline.base import BasePipeline
-from bosk.pipeline.builder.functional import FunctionalPipelineBuilder
-from bosk.executor.sklearn_interface import BoskPipelineClassifier
-from bosk.pipeline.connection import Connection
-from bosk.pipeline.dynamic import BaseDynamicPipeline
-from bosk.stages import Stage
-from bosk.utility import get_rand_int, get_random_generator
-from bosk.visitor.base import BaseVisitor
-from bosk.block.zoo.models.classification.classification_models import RFCBlock, ETCBlock
 import numpy as np
+import pandas as pd
 from sklearn.datasets import load_digits
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
-from sklearn.model_selection import BaseCrossValidator, StratifiedKFold
-
-from abc import ABC, abstractmethod
-from typing import Callable, List, Literal, Optional, Sequence, Tuple, Mapping, Type
-
-
-ModificationAction = Literal['add'] | Literal['remove']
-
-
-class ModifyGroupVisitor(BaseVisitor):
-    """Visitor for block groups modification, given a group and action.
-    """
-    def __init__(self, action: ModificationAction, group: BlockGroup):
-        self.action = action
-        self.group = group
-
-    @singledispatchmethod
-    def visit(self, obj):
-        pass  # ignore extra entities
-
-    @visit.register
-    def _(self, block: BaseBlock):
-        if self.action == 'add':
-            block.slots.groups.add(self.group)
-        elif self.action == 'remove':
-            block.slots.groups.remove(self.group)
-        else:
-            raise NotImplementedError()
-
-
-MetricsResults = Mapping[str, float]
-
-
-class MetricsEvaluator:
-    def __init__(self, names: List[str]):
-        self.names = set(names)
-        self.results = defaultdict(list)
-
-    def append_eval(self, y_true: np.ndarray, y_pred: np.ndarray):
-        pred_labels = np.argmax(y_pred, axis=1)
-        if 'roc_auc' in self.names:
-            self.results['roc_auc'].append(roc_auc_score(y_true, y_pred, multi_class='ovr'))
-        if 'f1' in self.names:
-            self.results['f1'].append(f1_score(y_true, pred_labels, average='macro'))
-        if 'accuracy' in self.names:
-            self.results['accuracy'].append(accuracy_score(y_true, pred_labels))
-
-    def average(self) -> MetricsResults:
-        return {
-            k: np.mean(v)
-            for k, v in self.results.items()
-        }
-
-
-class PipelineModelValidator:
-    need_refit = True
-
-    def __init__(self, cv: BaseCrossValidator,
-                 metrics_cls: Callable[[], MetricsEvaluator]):
-        self.cv = cv
-        self.metrics_cls = metrics_cls
-
-    def calc_metrics(self, data: Mapping[str, CPUData],
-                     fitter,
-                     transformer,
-                     output: str = 'proba') -> Optional[Mapping[str, float]]:
-        metrics = self.metrics_cls()
-        for train_idx, val_idx in self.cv.split(X.data, y.data):
-            train_data = {
-                k: CPUData(v.data[train_idx])
-                for k, v in data.items()
-            }
-            fitter(train_data)
-            val_data = {
-                k: CPUData(v.data[val_idx])
-                for k, v in data.items()
-            }
-            preds_val = transformer({k: v for k, v in val_data if k != 'y'})[output].data
-            metrics.append_eval(val_data['y'], preds_val)
-        return metrics.average()
-
-
-class DumbPipelineModelValidator(PipelineModelValidator):
-    need_refit = True
-
-    def __init__(self, cv: BaseCrossValidator,
-                 metrics_cls: Callable[[], MetricsEvaluator]):
-        self.cv = cv
-        self.metrics_cls = metrics_cls
-
-    def calc_metrics(self, data: Mapping[str, CPUData],
-                     fitter,
-                     transformer,
-                     output: str = 'proba') -> Optional[Mapping[str, float]]:
-        return None
-
-
-class TrainSetPipelineModelValidator(PipelineModelValidator):
-    need_refit = False
-
-    def __init__(self, cv: BaseCrossValidator,
-                 metrics_cls: Callable[[], MetricsEvaluator]):
-        self.cv = cv
-        self.metrics_cls = metrics_cls
-
-    def calc_metrics(self, data: Mapping[str, CPUData],
-                     fitter,
-                     transformer,
-                     output: str = 'proba') -> Optional[Mapping[str, float]]:
-        metrics = self.metrics_cls()
-        fitter(data)
-        preds = transformer({k: v for k, v in data.items() if k != 'y'})[output].data
-        metrics.append_eval(data['y'].data, preds)
-        return metrics.average()
-
-
-class Layer(ABC):
-    def __init__(self, executor_cls: Type[BaseExecutor],
-                 validator: PipelineModelValidator,
-                 layer_name: str = 'forests_layer',
-                 random_state: Optional[int] = None):
-        self.executor_cls = executor_cls
-        self.validator = validator
-        self.layer_name = layer_name
-        self.random_state = random_state
-
-    @property
-    @abstractmethod
-    def inputs(self):
-        ...
-
-    @abstractmethod
-    def fit(self, inputs: Mapping[str, BaseData]) -> Tuple[BasePipeline, MetricsResults]:
-        ...
-
-    def calc_metrics(self, data: Mapping[str, CPUData], pipeline: BasePipeline,
-                       output: str, fit_outputs: List[str]) -> Mapping[str, float]:
-        fitter = self.executor_cls(pipeline, Stage.FIT, outputs=[output, *fit_outputs])
-        transformer = self.executor_cls(pipeline, Stage.TRANSFORM)
-        return self.validator.calc_metrics(data, fitter, transformer, output)
-
-
-class MultiLayerPipelineBuilder(ABC):
-    def __init__(self):
-        pass
-
-    @abstractmethod
-    def append(self, layer: Layer):
-        pass
-
-
-class MGSLayer(Layer):
-    inputs = ['X', 'y']
-
-    def __init__(self, input_shape: Tuple[int], **kwargs):
-        super().__init__(**kwargs)
-        self.input_shape = input_shape
-
-    def fit(self, data: Mapping[str, BaseData]):
-        rng = get_random_generator(self.random_state)
-        b = FunctionalPipelineBuilder()
-        x_ = b.Input('X')()
-        y_ = b.Input('y')()
-        reshaped_ = b.Reshape((-1, *self.input_shape))(x_)
-        ms = b.MGSRandomFerns(
-            n_groups=5,
-            n_ferns_in_group=5,
-            fern_size=5,
-            kind='binary',
-            bootstrap=True,
-            n_jobs=-1,
-            random_state=get_rand_int(rng),
-            kernel_size=4,
-            stride=4,
-            dilation=1,
-            padding=None
-        )(X=reshaped_, y=y_)
-        pooled = b.Pooling(
-            kernel_size=2,
-            stride=None,
-            dilation=1,
-            aggregation='max',
-        )(X=ms)
-        pooled = b.Flatten()(X=pooled)
-        proba = b.RandomFerns(
-            n_groups=5,
-            n_ferns_in_group=5,
-            fern_size=5,
-            kind='unary',
-            bootstrap=True,
-            n_jobs=-1,
-            random_state=get_rand_int(rng),
-        )(X=pooled, y=y_)
-        embedding_output = b.Output('X')(b.Stack(['pooled', 'proba'])(pooled=pooled, proba=proba))
-        proba_output = b.Output('proba')(proba)
-        pipeline = b.build()
-        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
-        # evaluate the pipeline
-        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
-
-        # fit on the whole given data set
-        if self.validator.need_refit:
-            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba'])
-            fitter(data)
-        return pipeline, metric_values
-
-
-
-class ForestsLayer(Layer):
-    inputs = ['X', 'X_original', 'y']
-
-    def fit(self, data: Mapping[str, BaseData]):
-        rng = get_random_generator(self.random_state)
-        # forests layer leverages CPU algorithms
-        data = {
-            k: v.to_cpu()
-            for k, v in data.items()
-        }
-
-        # build a fixed pipeline
-        b = FunctionalPipelineBuilder()
-        x_ = b.Input('X')()
-        x_original_ = b.Input('X_original')()
-        y_ = b.TargetInput('y')()
-
-        rf_ = b.RFC(random_state=get_rand_int(rng))(X=x_, y=y_)
-        et_ = b.ETC(random_state=get_rand_int(rng))(X=x_, y=y_)
-        embedding_ = b.Concat(['X_original', 'rf', 'et'], axis=1)(X_original=x_original_, rf=rf_, et=et_)
-        embedding_output = b.Output('X')(embedding_)
-        original_output = b.Output('X_original')(x_original_)
-
-        proba_ = b.Average(axis=-1)(b.Stack(['rf', 'et'], axis=-1)(rf=rf_, et=et_))
-        proba_output = b.Output('proba')(proba_)
-
-        pipeline = b.build()
-        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
-        # evaluate the pipeline
-        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
-
-        # fit on the whole given data set
-        if self.validator.need_refit:
-            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba', 'X'])
-            fitter(data)
-        return pipeline, metric_values
-
-
-class FitBlacklistBlockExecutor(DefaultBlockExecutor):
-    """Block executor that does not call `fit` method for the blocks in the black list.
-
-    It is used to be able to manually fit some blocks of the pipeline.
-    """
-    def __init__(self, blacklist: Sequence[BaseBlock]) -> None:
-        super().__init__()
-        self.blacklist = set(blacklist)
-
-    def execute_block(self, stage: Stage, block: BaseBlock,
-                        block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
-        if block in self.blacklist:
-            # avoid block fitting
-            filtered_block_input_mapping = {
-                slot.meta.name: values
-                for slot, values in block_input_mapping.items()
-                if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit)
-            }
-            return block.wrap(block.transform(filtered_block_input_mapping))
-        return super().execute_block(stage, block, block_input_mapping)
-
-
-class StackingLayer(Layer):
-    inputs = ['X', 'X_original', 'y']
-
-    def __init__(self, make_blocks: Callable[[], Sequence[BaseBlock]],
-                 executor_cls: Type[BaseExecutor],
-                 validator: PipelineModelValidator,
-                 layer_name: str = 'stacking_layer',
-                 random_state: Optional[int] = None):
-        super().__init__(
-            executor_cls=executor_cls,
-            validator=validator,
-            layer_name=layer_name,
-            random_state=random_state,
-        )
-        self.make_blocks = make_blocks
-
-    def __custom_cross_validate(self, data: Mapping[str, BaseData], pipeline: BasePipeline,
-                       blocks: List[BaseBlock], rng: np.random.RandomState) -> Mapping[str, float]:
-        fitter = self._make_fitter(pipeline, blocks, rng)
-        transformer = self.executor_cls(pipeline, Stage.TRANSFORM)
-        return self.validator.calc_metrics(data, fitter, transformer, 'proba')
-
-    def _make_fitter(self, pipeline: BasePipeline, blocks: List[BaseBlock], rng: np.random.RandomState):
-        new_rng = get_random_generator(get_rand_int(rng))
-        basic_fitter = self.executor_cls(pipeline, Stage.FIT, block_executor=FitBlacklistBlockExecutor(blocks))
-        def _fit_fn(inputs: Mapping[str, CPUData]):
-            kfold = StratifiedKFold(n_splits=len(blocks), shuffle=True, random_state=get_rand_int(new_rng))
-            inp_X, inp_y = inputs['X'].data, inputs['y'].data
-            split_gen = kfold.split(inp_X, inp_y)
-            for i, (block_train_idx, _rest_idx) in enumerate(split_gen):
-                blocks[i].fit({'X': inp_X[block_train_idx], 'y': inp_y[block_train_idx]})
-            basic_fitter(inputs)
-            return None
-        return _fit_fn
-
-    def fit(self, data: Mapping[str, BaseData]):
-        rng = get_random_generator(self.random_state)
-        # forests layer leverages CPU algorithms
-        data = {
-            k: v.to_cpu()
-            for k, v in data.items()
-        }
-
-        # build a fixed pipeline
-        b = FunctionalPipelineBuilder()
-        x_ = b.Input('X')()
-        x_original_ = b.Input('X_original')()
-        y_ = b.TargetInput('y')()
-
-        blocks = self.make_blocks()
-        block_wrappers = [
-            b.wrap(block)(X=x_, y=y_)
-            for block in blocks
-        ]
-        # set random states
-        for bw in block_wrappers:
-            bw.block.set_random_state(get_rand_int(rng))
-        block_names = [f'block_{i}' for i in range(len(block_wrappers))]
-        named_block_wrappers = dict(zip(block_names, block_wrappers))
-
-        embedding_ = b.Concat(['X_original', *block_names], axis=1)(X_original=x_original_, **named_block_wrappers)
-        embedding_output = b.Output('X')(embedding_)
-        original_output = b.Output('X_original')(x_original_)
-
-        proba_ = b.Average(axis=-1)(b.Stack(block_names, axis=-1)(**named_block_wrappers))
-        proba_output = b.Output('proba')(proba_)
-
-        pipeline = b.build()
-        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
-        # evaluate the pipeline
-        blocks = [w.block for w in block_wrappers]
-        metric_values = self.__custom_cross_validate(data, pipeline, blocks, rng)
-
-        # fit on the whole given data set
-        if self.validator.need_refit:
-            fitter = self._make_fitter(pipeline, blocks, rng)
-            fitter(data)
-        return pipeline, metric_values
-
-
-class GrowingStrategy(ABC):
-    @abstractmethod
-    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
-        ...
-
-    def trim(self, pipelines: Sequence[BasePipeline]):
-        return pipelines
-
-
-class EarlyStopping(GrowingStrategy):
-    def __init__(self, mode: Literal['any'] | Literal['all'] = 'all', patience: int = 1):
-        self.mode = mode
-        self.patience = patience
-
-    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
-        assert metrics is not None, 'Please, calculate CV metrics first'
-        if 'metrics' not in growing_state:
-            growing_state['metrics'] = metrics
-            growing_state['count'] = 0
-            return True
-        MODES = {
-            'any': any,
-            'all': all
-        }
-        prev_metrics = growing_state['metrics']
-        # check if new metrics are lower than previous
-        new_metrics_worse = MODES[self.mode](
-            metrics[metric_name] <= prev_metrics[metric_name]
-            for metric_name in metrics.keys()
-        )
-        if new_metrics_worse:
-            growing_state['count'] += 1
-            if growing_state['count'] > self.patience:
-                return False
-        else:
-            growing_state['count'] = 0
-        return True
-
-    def trim(self, pipelines: List[BasePipeline], growing_state: dict):
-        """Trim the last `count` pipelines.
-        """
-        count = growing_state['count']
-        if count > 0:
-            return pipelines[:-count]
-        return pipelines
-
-
-class SequencePipelineMaker(MultiLayerPipelineBuilder):
-    def __init__(self, executor_cls: Type[BaseExecutor],
-                 growing_strategy: Optional[GrowingStrategy] = None,
-                 **inputs: Mapping[str, BaseData]):
-        super().__init__()
-        self.executor_cls = executor_cls
-        self.inputs = inputs
-        self.prev_step_inputs = None
-        self.pipelines = []
-        self.growing_strategy = growing_strategy
-        self.__growing_state = dict()
-        self.finished = False
-
-    def append(self, layer: Layer) -> bool:
-        if self.finished:
-            return False
-        if self.prev_step_inputs is None:
-            step_inputs = self.inputs
-        else:
-            prev_pipeline = self.pipelines[-1]
-            available_outputs = [k for k in layer.inputs if k in prev_pipeline.outputs]
-            prev_transformer = self.executor_cls(prev_pipeline, Stage.TRANSFORM, outputs=available_outputs)
-            step_inputs = prev_transformer(self.prev_step_inputs)
-        # append static inputs (e.g. 'y')
-        step_inputs = {**step_inputs}
-        step_inputs.update({
-            k: self.inputs[k]
-            for k in layer.inputs
-            if k not in step_inputs
-        })
-        pipeline, metrics = layer.fit(step_inputs)
-        self.pipelines.append(pipeline)
-        self.prev_step_inputs = step_inputs
-        if not self.growing_strategy.need_grow(pipeline, metrics, self.executor_cls, self.__growing_state):
-            self.pipelines = self.growing_strategy.trim(self.pipelines, self.__growing_state)
-            self.finished = True
-            return False
-        return True
-
-    def build(self):
-        nodes = []
-        connections = []
-        inputs = self.pipelines[0].inputs
-        outputs = self.pipelines[-1].outputs
-
-        for i, pipeline in enumerate(self.pipelines):
-            nodes.extend(pipeline.nodes)
-            connections.extend(pipeline.connections)
-            if i != 0:
-                prev_pipeline = self.pipelines[i - 1]
-                for out_name, out_slot in prev_pipeline.outputs.items():
-                    if out_name in pipeline.inputs:
-                        # matching slots by names
-                        connections.append(Connection(out_slot, pipeline.inputs[out_name]))
-
-        return BasePipeline(
-            nodes=nodes,
-            connections=connections,
-            inputs=inputs,
-            outputs=outputs,
-        )
+from sklearn.model_selection import StratifiedKFold
+
+from bosk.auto.deep_forest import ClassicalDeepForestConstructor
+from bosk.auto.validation import TrainSetPipelineModelValidator
+from bosk.data import CPUData
+from bosk.executor.recursive import RecursiveExecutor
+from bosk.executor.topological import TopologicalExecutor
+from bosk.painter.topological import TopologicalPainter
+from bosk.executor.sklearn_interface import BoskPipelineClassifier
+from bosk.auto.metrics import MetricsEvaluator
 
 
 def make_fit_model(X: np.ndarray, y: np.ndarray):
     X = CPUData(X)
     y = CPUData(y)
 
-    executor_cls = RecursiveExecutor
-    # validator = PipelineModelValidator(
-    # validator = DumbPipelineModelValidator(
-    validator = TrainSetPipelineModelValidator(
-        StratifiedKFold(n_splits=5, shuffle=True, random_state=12345),
-        lambda: MetricsEvaluator(['f1', 'roc_auc']),
+    constructor = ClassicalDeepForestConstructor(
+        TopologicalExecutor,
+        rf_params=dict(),
+        max_iter=10,
+        layer_width=2,
+        cv=2,
+        random_state=12345,
+        # make_metrics=lambda: MetricsEvaluator(['f1', 'roc_auc']),
     )
-    # pipeline, metrics = MGSLayer(
-    #     input_shape=(1, 8, 8),
-    #     executor_cls=executor_cls,
-    #     validator=validator
-    # ).fit(X, y)
-    # print(metrics)
+    pipeline = constructor.construct(X.data, y.data)
 
-    # pipeline, metrics = ForestsLayer(
-    #     executor_cls=executor_cls,
-    #     validator=validator
-    # ).fit(X, y)
-    # print(metrics)
-
-    # pipeline, metrics = StackingLayer(
-    #     executor_cls=executor_cls,
-    #     validator=validator,
-    #     random_state=12345
-    # ).fit(X, y)
-    # print(metrics)
-
-
-
-    rng = get_random_generator(12345)
-    maker = SequencePipelineMaker(
-        executor_cls,
-        growing_strategy=EarlyStopping(),
-        X=X,
-        X_original=X,
-        y=y
-    )
-    maker.append(ForestsLayer(
-        executor_cls=executor_cls,
-        validator=validator,
-        random_state=get_rand_int(rng)
-    ))
-    maker.append(StackingLayer(
-        make_blocks=lambda: [RFCBlock(), ETCBlock(), RFCBlock(), ETCBlock()],
-        executor_cls=executor_cls,
-        validator=validator,
-        random_state=get_rand_int(rng)
-    ))
-    maker.append(StackingLayer(
-        make_blocks=lambda: [RFCBlock(), ETCBlock(), RFCBlock(), ETCBlock()],
-        executor_cls=executor_cls,
-        validator=validator,
-        random_state=get_rand_int(rng)
-    ))
-    maker.append(StackingLayer(
-        make_blocks=lambda: [RFCBlock(), ETCBlock(), RFCBlock(), ETCBlock()],
-        executor_cls=executor_cls,
-        validator=validator,
-        random_state=get_rand_int(rng)
-    ))
-
-    pipeline = maker.build()
+    print(pd.DataFrame(constructor.history))
 
     # make a scikit-learn model
-    model = BoskPipelineClassifier(pipeline, executor_cls=RecursiveExecutor)
+    model = BoskPipelineClassifier(pipeline, executor_cls=TopologicalExecutor)
     model._classifier_init(y.data)
     return model
 
@@ -557,7 +45,23 @@ def main():
     model = make_fit_model(X_train, y_train)
     # predict with the model
     test_preds = model.predict(X_test)
+    test_proba = model.predict_proba(X_test)
     print('Test f1 score:', f1_score(y_test, test_preds, average='macro'))
+    print('Test roc_auc score:', roc_auc_score(y_test, test_proba, multi_class='ovr'))
+    # draw
+    painter = TopologicalPainter()
+    painter.from_pipeline(model.pipeline)
+    filename = 'deep_forest'
+    painter.render(filename, 'png')
+    # retraining
+    print('Retrain')
+    model.fit(X_train, y_train)
+    print('Predict')
+    test_preds = model.predict(X_test)
+    print('Predict proba')
+    test_proba = model.predict_proba(X_test)
+    print('Test f1 score:', f1_score(y_test, test_preds, average='macro'))
+    print('Test roc_auc score:', roc_auc_score(y_test, test_proba, multi_class='ovr'))
 
 
 if __name__ == '__main__':

--- a/examples/deep_forests/automatic/automatic.py
+++ b/examples/deep_forests/automatic/automatic.py
@@ -1,0 +1,564 @@
+from collections import defaultdict
+from functools import singledispatchmethod
+from bosk.block.base import BaseBlock, BaseInputBlock, BlockOutputData
+from bosk.block.functional import FunctionalBlockWrapper
+from bosk.block.slot import BlockGroup, BlockInputSlot, BlockOutputSlot
+from bosk.data import BaseData, CPUData
+from bosk.executor.base import BaseBlockExecutor, BaseExecutor, DefaultBlockExecutor, InputSlotToDataMapping
+from bosk.executor.recursive import RecursiveExecutor
+from bosk.pipeline.base import BasePipeline
+from bosk.pipeline.builder.functional import FunctionalPipelineBuilder
+from bosk.executor.sklearn_interface import BoskPipelineClassifier
+from bosk.pipeline.connection import Connection
+from bosk.pipeline.dynamic import BaseDynamicPipeline
+from bosk.stages import Stage
+from bosk.utility import get_rand_int, get_random_generator
+from bosk.visitor.base import BaseVisitor
+from bosk.block.zoo.models.classification.classification_models import RFCBlock, ETCBlock
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
+from sklearn.model_selection import BaseCrossValidator, StratifiedKFold
+
+from abc import ABC, abstractmethod
+from typing import Callable, List, Literal, Optional, Sequence, Tuple, Mapping, Type
+
+
+ModificationAction = Literal['add'] | Literal['remove']
+
+
+class ModifyGroupVisitor(BaseVisitor):
+    """Visitor for block groups modification, given a group and action.
+    """
+    def __init__(self, action: ModificationAction, group: BlockGroup):
+        self.action = action
+        self.group = group
+
+    @singledispatchmethod
+    def visit(self, obj):
+        pass  # ignore extra entities
+
+    @visit.register
+    def _(self, block: BaseBlock):
+        if self.action == 'add':
+            block.slots.groups.add(self.group)
+        elif self.action == 'remove':
+            block.slots.groups.remove(self.group)
+        else:
+            raise NotImplementedError()
+
+
+MetricsResults = Mapping[str, float]
+
+
+class MetricsEvaluator:
+    def __init__(self, names: List[str]):
+        self.names = set(names)
+        self.results = defaultdict(list)
+
+    def append_eval(self, y_true: np.ndarray, y_pred: np.ndarray):
+        pred_labels = np.argmax(y_pred, axis=1)
+        if 'roc_auc' in self.names:
+            self.results['roc_auc'].append(roc_auc_score(y_true, y_pred, multi_class='ovr'))
+        if 'f1' in self.names:
+            self.results['f1'].append(f1_score(y_true, pred_labels, average='macro'))
+        if 'accuracy' in self.names:
+            self.results['accuracy'].append(accuracy_score(y_true, pred_labels))
+
+    def average(self) -> MetricsResults:
+        return {
+            k: np.mean(v)
+            for k, v in self.results.items()
+        }
+
+
+class PipelineModelValidator:
+    need_refit = True
+
+    def __init__(self, cv: BaseCrossValidator,
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        self.cv = cv
+        self.metrics_cls = metrics_cls
+
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        metrics = self.metrics_cls()
+        for train_idx, val_idx in self.cv.split(X.data, y.data):
+            train_data = {
+                k: CPUData(v.data[train_idx])
+                for k, v in data.items()
+            }
+            fitter(train_data)
+            val_data = {
+                k: CPUData(v.data[val_idx])
+                for k, v in data.items()
+            }
+            preds_val = transformer({k: v for k, v in val_data if k != 'y'})[output].data
+            metrics.append_eval(val_data['y'], preds_val)
+        return metrics.average()
+
+
+class DumbPipelineModelValidator(PipelineModelValidator):
+    need_refit = True
+
+    def __init__(self, cv: BaseCrossValidator,
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        self.cv = cv
+        self.metrics_cls = metrics_cls
+
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        return None
+
+
+class TrainSetPipelineModelValidator(PipelineModelValidator):
+    need_refit = False
+
+    def __init__(self, cv: BaseCrossValidator,
+                 metrics_cls: Callable[[], MetricsEvaluator]):
+        self.cv = cv
+        self.metrics_cls = metrics_cls
+
+    def calc_metrics(self, data: Mapping[str, CPUData],
+                     fitter,
+                     transformer,
+                     output: str = 'proba') -> Optional[Mapping[str, float]]:
+        metrics = self.metrics_cls()
+        fitter(data)
+        preds = transformer({k: v for k, v in data.items() if k != 'y'})[output].data
+        metrics.append_eval(data['y'].data, preds)
+        return metrics.average()
+
+
+class Layer(ABC):
+    def __init__(self, executor_cls: Type[BaseExecutor],
+                 validator: PipelineModelValidator,
+                 layer_name: str = 'forests_layer',
+                 random_state: Optional[int] = None):
+        self.executor_cls = executor_cls
+        self.validator = validator
+        self.layer_name = layer_name
+        self.random_state = random_state
+
+    @property
+    @abstractmethod
+    def inputs(self):
+        ...
+
+    @abstractmethod
+    def fit(self, inputs: Mapping[str, BaseData]) -> Tuple[BasePipeline, MetricsResults]:
+        ...
+
+    def calc_metrics(self, data: Mapping[str, CPUData], pipeline: BasePipeline,
+                       output: str, fit_outputs: List[str]) -> Mapping[str, float]:
+        fitter = self.executor_cls(pipeline, Stage.FIT, outputs=[output, *fit_outputs])
+        transformer = self.executor_cls(pipeline, Stage.TRANSFORM)
+        return self.validator.calc_metrics(data, fitter, transformer, output)
+
+
+class MultiLayerPipelineBuilder(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def append(self, layer: Layer):
+        pass
+
+
+class MGSLayer(Layer):
+    inputs = ['X', 'y']
+
+    def __init__(self, input_shape: Tuple[int], **kwargs):
+        super().__init__(**kwargs)
+        self.input_shape = input_shape
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        y_ = b.Input('y')()
+        reshaped_ = b.Reshape((-1, *self.input_shape))(x_)
+        ms = b.MGSRandomFerns(
+            n_groups=5,
+            n_ferns_in_group=5,
+            fern_size=5,
+            kind='binary',
+            bootstrap=True,
+            n_jobs=-1,
+            random_state=get_rand_int(rng),
+            kernel_size=4,
+            stride=4,
+            dilation=1,
+            padding=None
+        )(X=reshaped_, y=y_)
+        pooled = b.Pooling(
+            kernel_size=2,
+            stride=None,
+            dilation=1,
+            aggregation='max',
+        )(X=ms)
+        pooled = b.Flatten()(X=pooled)
+        proba = b.RandomFerns(
+            n_groups=5,
+            n_ferns_in_group=5,
+            fern_size=5,
+            kind='unary',
+            bootstrap=True,
+            n_jobs=-1,
+            random_state=get_rand_int(rng),
+        )(X=pooled, y=y_)
+        embedding_output = b.Output('X')(b.Stack(['pooled', 'proba'])(pooled=pooled, proba=proba))
+        proba_output = b.Output('proba')(proba)
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba'])
+            fitter(data)
+        return pipeline, metric_values
+
+
+
+class ForestsLayer(Layer):
+    inputs = ['X', 'X_original', 'y']
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        # forests layer leverages CPU algorithms
+        data = {
+            k: v.to_cpu()
+            for k, v in data.items()
+        }
+
+        # build a fixed pipeline
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        x_original_ = b.Input('X_original')()
+        y_ = b.TargetInput('y')()
+
+        rf_ = b.RFC(random_state=get_rand_int(rng))(X=x_, y=y_)
+        et_ = b.ETC(random_state=get_rand_int(rng))(X=x_, y=y_)
+        embedding_ = b.Concat(['X_original', 'rf', 'et'], axis=1)(X_original=x_original_, rf=rf_, et=et_)
+        embedding_output = b.Output('X')(embedding_)
+        original_output = b.Output('X_original')(x_original_)
+
+        proba_ = b.Average(axis=-1)(b.Stack(['rf', 'et'], axis=-1)(rf=rf_, et=et_))
+        proba_output = b.Output('proba')(proba_)
+
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        metric_values = self.calc_metrics(data, pipeline, 'proba', ['X'])
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self.executor_cls(pipeline, Stage.FIT, outputs=['proba', 'X'])
+            fitter(data)
+        return pipeline, metric_values
+
+
+class FitBlacklistBlockExecutor(DefaultBlockExecutor):
+    """Block executor that does not call `fit` method for the blocks in the black list.
+
+    It is used to be able to manually fit some blocks of the pipeline.
+    """
+    def __init__(self, blacklist: Sequence[BaseBlock]) -> None:
+        super().__init__()
+        self.blacklist = set(blacklist)
+
+    def execute_block(self, stage: Stage, block: BaseBlock,
+                        block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        if block in self.blacklist:
+            # avoid block fitting
+            filtered_block_input_mapping = {
+                slot.meta.name: values
+                for slot, values in block_input_mapping.items()
+                if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit)
+            }
+            return block.wrap(block.transform(filtered_block_input_mapping))
+        return super().execute_block(stage, block, block_input_mapping)
+
+
+class StackingLayer(Layer):
+    inputs = ['X', 'X_original', 'y']
+
+    def __init__(self, make_blocks: Callable[[], Sequence[BaseBlock]],
+                 executor_cls: Type[BaseExecutor],
+                 validator: PipelineModelValidator,
+                 layer_name: str = 'stacking_layer',
+                 random_state: Optional[int] = None):
+        super().__init__(
+            executor_cls=executor_cls,
+            validator=validator,
+            layer_name=layer_name,
+            random_state=random_state,
+        )
+        self.make_blocks = make_blocks
+
+    def __custom_cross_validate(self, data: Mapping[str, BaseData], pipeline: BasePipeline,
+                       blocks: List[BaseBlock], rng: np.random.RandomState) -> Mapping[str, float]:
+        fitter = self._make_fitter(pipeline, blocks, rng)
+        transformer = self.executor_cls(pipeline, Stage.TRANSFORM)
+        return self.validator.calc_metrics(data, fitter, transformer, 'proba')
+
+    def _make_fitter(self, pipeline: BasePipeline, blocks: List[BaseBlock], rng: np.random.RandomState):
+        new_rng = get_random_generator(get_rand_int(rng))
+        basic_fitter = self.executor_cls(pipeline, Stage.FIT, block_executor=FitBlacklistBlockExecutor(blocks))
+        def _fit_fn(inputs: Mapping[str, CPUData]):
+            kfold = StratifiedKFold(n_splits=len(blocks), shuffle=True, random_state=get_rand_int(new_rng))
+            inp_X, inp_y = inputs['X'].data, inputs['y'].data
+            split_gen = kfold.split(inp_X, inp_y)
+            for i, (block_train_idx, _rest_idx) in enumerate(split_gen):
+                blocks[i].fit({'X': inp_X[block_train_idx], 'y': inp_y[block_train_idx]})
+            basic_fitter(inputs)
+            return None
+        return _fit_fn
+
+    def fit(self, data: Mapping[str, BaseData]):
+        rng = get_random_generator(self.random_state)
+        # forests layer leverages CPU algorithms
+        data = {
+            k: v.to_cpu()
+            for k, v in data.items()
+        }
+
+        # build a fixed pipeline
+        b = FunctionalPipelineBuilder()
+        x_ = b.Input('X')()
+        x_original_ = b.Input('X_original')()
+        y_ = b.TargetInput('y')()
+
+        blocks = self.make_blocks()
+        block_wrappers = [
+            b.wrap(block)(X=x_, y=y_)
+            for block in blocks
+        ]
+        # set random states
+        for bw in block_wrappers:
+            bw.block.set_random_state(get_rand_int(rng))
+        block_names = [f'block_{i}' for i in range(len(block_wrappers))]
+        named_block_wrappers = dict(zip(block_names, block_wrappers))
+
+        embedding_ = b.Concat(['X_original', *block_names], axis=1)(X_original=x_original_, **named_block_wrappers)
+        embedding_output = b.Output('X')(embedding_)
+        original_output = b.Output('X_original')(x_original_)
+
+        proba_ = b.Average(axis=-1)(b.Stack(block_names, axis=-1)(**named_block_wrappers))
+        proba_output = b.Output('proba')(proba_)
+
+        pipeline = b.build()
+        pipeline.accept(ModifyGroupVisitor('add', BlockGroup(self.layer_name)))
+        # evaluate the pipeline
+        blocks = [w.block for w in block_wrappers]
+        metric_values = self.__custom_cross_validate(data, pipeline, blocks, rng)
+
+        # fit on the whole given data set
+        if self.validator.need_refit:
+            fitter = self._make_fitter(pipeline, blocks, rng)
+            fitter(data)
+        return pipeline, metric_values
+
+
+class GrowingStrategy(ABC):
+    @abstractmethod
+    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
+        ...
+
+    def trim(self, pipelines: Sequence[BasePipeline]):
+        return pipelines
+
+
+class EarlyStopping(GrowingStrategy):
+    def __init__(self, mode: Literal['any'] | Literal['all'] = 'all', patience: int = 1):
+        self.mode = mode
+        self.patience = patience
+
+    def need_grow(self, pipeline, metrics, executor_cls, growing_state: dict) -> bool:
+        assert metrics is not None, 'Please, calculate CV metrics first'
+        if 'metrics' not in growing_state:
+            growing_state['metrics'] = metrics
+            growing_state['count'] = 0
+            return True
+        MODES = {
+            'any': any,
+            'all': all
+        }
+        prev_metrics = growing_state['metrics']
+        # check if new metrics are lower than previous
+        new_metrics_worse = MODES[self.mode](
+            metrics[metric_name] <= prev_metrics[metric_name]
+            for metric_name in metrics.keys()
+        )
+        if new_metrics_worse:
+            growing_state['count'] += 1
+            if growing_state['count'] > self.patience:
+                return False
+        else:
+            growing_state['count'] = 0
+        return True
+
+    def trim(self, pipelines: List[BasePipeline], growing_state: dict):
+        """Trim the last `count` pipelines.
+        """
+        count = growing_state['count']
+        if count > 0:
+            return pipelines[:-count]
+        return pipelines
+
+
+class SequencePipelineMaker(MultiLayerPipelineBuilder):
+    def __init__(self, executor_cls: Type[BaseExecutor],
+                 growing_strategy: Optional[GrowingStrategy] = None,
+                 **inputs: Mapping[str, BaseData]):
+        super().__init__()
+        self.executor_cls = executor_cls
+        self.inputs = inputs
+        self.prev_step_inputs = None
+        self.pipelines = []
+        self.growing_strategy = growing_strategy
+        self.__growing_state = dict()
+        self.finished = False
+
+    def append(self, layer: Layer) -> bool:
+        if self.finished:
+            return False
+        if self.prev_step_inputs is None:
+            step_inputs = self.inputs
+        else:
+            prev_pipeline = self.pipelines[-1]
+            available_outputs = [k for k in layer.inputs if k in prev_pipeline.outputs]
+            prev_transformer = self.executor_cls(prev_pipeline, Stage.TRANSFORM, outputs=available_outputs)
+            step_inputs = prev_transformer(self.prev_step_inputs)
+        # append static inputs (e.g. 'y')
+        step_inputs = {**step_inputs}
+        step_inputs.update({
+            k: self.inputs[k]
+            for k in layer.inputs
+            if k not in step_inputs
+        })
+        pipeline, metrics = layer.fit(step_inputs)
+        self.pipelines.append(pipeline)
+        self.prev_step_inputs = step_inputs
+        if not self.growing_strategy.need_grow(pipeline, metrics, self.executor_cls, self.__growing_state):
+            self.pipelines = self.growing_strategy.trim(self.pipelines, self.__growing_state)
+            self.finished = True
+            return False
+        return True
+
+    def build(self):
+        nodes = []
+        connections = []
+        inputs = self.pipelines[0].inputs
+        outputs = self.pipelines[-1].outputs
+
+        for i, pipeline in enumerate(self.pipelines):
+            nodes.extend(pipeline.nodes)
+            connections.extend(pipeline.connections)
+            if i != 0:
+                prev_pipeline = self.pipelines[i - 1]
+                for out_name, out_slot in prev_pipeline.outputs.items():
+                    if out_name in pipeline.inputs:
+                        # matching slots by names
+                        connections.append(Connection(out_slot, pipeline.inputs[out_name]))
+
+        return BasePipeline(
+            nodes=nodes,
+            connections=connections,
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+
+def make_fit_model(X: np.ndarray, y: np.ndarray):
+    X = CPUData(X)
+    y = CPUData(y)
+
+    executor_cls = RecursiveExecutor
+    # validator = PipelineModelValidator(
+    # validator = DumbPipelineModelValidator(
+    validator = TrainSetPipelineModelValidator(
+        StratifiedKFold(n_splits=5, shuffle=True, random_state=12345),
+        lambda: MetricsEvaluator(['f1', 'roc_auc']),
+    )
+    # pipeline, metrics = MGSLayer(
+    #     input_shape=(1, 8, 8),
+    #     executor_cls=executor_cls,
+    #     validator=validator
+    # ).fit(X, y)
+    # print(metrics)
+
+    # pipeline, metrics = ForestsLayer(
+    #     executor_cls=executor_cls,
+    #     validator=validator
+    # ).fit(X, y)
+    # print(metrics)
+
+    # pipeline, metrics = StackingLayer(
+    #     executor_cls=executor_cls,
+    #     validator=validator,
+    #     random_state=12345
+    # ).fit(X, y)
+    # print(metrics)
+
+
+
+    rng = get_random_generator(12345)
+    maker = SequencePipelineMaker(
+        executor_cls,
+        growing_strategy=EarlyStopping(),
+        X=X,
+        X_original=X,
+        y=y
+    )
+    maker.append(ForestsLayer(
+        executor_cls=executor_cls,
+        validator=validator,
+        random_state=get_rand_int(rng)
+    ))
+    maker.append(StackingLayer(
+        make_blocks=lambda: [RFCBlock(), ETCBlock(), RFCBlock(), ETCBlock()],
+        executor_cls=executor_cls,
+        validator=validator,
+        random_state=get_rand_int(rng)
+    ))
+    maker.append(StackingLayer(
+        make_blocks=lambda: [RFCBlock(), ETCBlock(), RFCBlock(), ETCBlock()],
+        executor_cls=executor_cls,
+        validator=validator,
+        random_state=get_rand_int(rng)
+    ))
+    maker.append(StackingLayer(
+        make_blocks=lambda: [RFCBlock(), ETCBlock(), RFCBlock(), ETCBlock()],
+        executor_cls=executor_cls,
+        validator=validator,
+        random_state=get_rand_int(rng)
+    ))
+
+    pipeline = maker.build()
+
+    # make a scikit-learn model
+    model = BoskPipelineClassifier(pipeline, executor_cls=RecursiveExecutor)
+    model._classifier_init(y.data)
+    return model
+
+
+def main():
+    all_X, all_y = load_digits(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(all_X, all_y, random_state=12345)
+    # fit the model
+    model = make_fit_model(X_train, y_train)
+    # predict with the model
+    test_preds = model.predict(X_test)
+    print('Test f1 score:', f1_score(y_test, test_preds, average='macro'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A new module for automatic layerwise Deep Forest construction called `bosk.auto` has been added.
It contains:

- Layers – small pipeline builders that can build, fit and evaluate pipelines;
- Sequential pipeline builder that can glue multiple pipelines into one;
- Deep Forest constructors that automatically build large pipelines based on data;
- Growing strategies, pipeline model validators and metrics – for implementation of things above.


Changes:

- Blocks now have `default_output` property. If block has more than one output this property determines which to use by default. If a block has equally important outputs, it should stress that: `default_output=None`;
- Blocks can belong to one or multiple groups. The groups can be used to unify blocks into Deep Forest layers (e.g. for layer freezing);
- Group modification visitor has been added for applying group modification operations to pipelines;
- - `GraphvizPainter` now can draw the groups;
- Functional Pipeline Builder now have more concrete type hints;
- Topological Executor warnings became more useful;
- `MultiGrainedScanningNDBlock` base estimator handling has been fixed (in case when base estimator is a block);

New blocks:

- **Global Average Pooling** – for spatial dimensions reduction (allows to apply built pipeline to new data with different shape, for example to larger images);
- **Cross-validation stacking** (`CVTrainIndicesBlock`, `SubsetTrainWrapperBlock`) – routing blocks for cross-validation based stacking implementation. The former one produces training indices at the FIT stage and the later one wraps any block and fits it only on samples with indices from the given "training_indices" subset.
