### PR TITLE
Add initial implementation of eager evaluations

### DIFF
--- a/bosk/block/eager.py
+++ b/bosk/block/eager.py
@@ -1,0 +1,92 @@
+from ..executor.block import BaseBlockExecutor, InputSlotToDataMapping
+from ..block.base import BaseBlock, BlockOutputData
+from ..data import BaseData
+from ..stages import Stage
+from .functional import FunctionalBlockWrapper
+from typing import Optional, Mapping
+
+
+class EagerBlockState:
+    """Eager block state, containing the results of block execution (output data).
+
+    The block state is strongly related to the block, but not to its wrapper.
+    I.e. it can be shared between different block wrappers corresponding to the same block.
+
+    Attributes:
+        fit_output_values: Eagerly calculated output values of the block.
+                           When `None`, the block has not yet been executed.
+
+    """
+    def __init__(self):
+        self.fit_output_values: Optional[Mapping[str, BaseData]] = None
+
+
+class EagerBlockWrapper(FunctionalBlockWrapper):
+    """Block wrapper that contains the evaluation state (its output data).
+
+    It can be used for eager evaluations at pipeline construction step.
+    Comparing to a regular `FunctionalBlockWrapper`, it can be executed by `execute(...)`
+    and return calculated output data by `get_output_data()`.
+
+    Attributes:
+        executor: Block executor.
+        state: Eager block state.
+
+    Args:
+        block: Block to be wrapped.
+        executor: Block executor that will be applied to th block to update the state.
+        output_name: Output slot name (the same as in `FunctionalBlockWrapper`),
+                     is used to specify which output is needed.
+
+    """
+    def __init__(self, block: BaseBlock, executor: BaseBlockExecutor,
+                 output_name: Optional[str] = None):
+        super().__init__(block, output_name=output_name)
+        self.executor = executor
+        self.state = EagerBlockState()
+
+    def execute(self, block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        """Execute the underlying block with the given inputs and store the result in the state.
+
+        The result stored in `fit_output_values` and can be accessed by `get_output_data()`.
+
+        Args:
+            inputs: Block inputs.
+
+        """
+        assert self.state.fit_output_values is None, 'Cannot fit the eager block twice'
+        block_output_data = self.executor.execute_block(
+            stage=Stage.FIT,
+            block=self.block,
+            block_input_mapping=block_input_mapping,
+        )
+        self.state.fit_output_values = block_output_data
+        return block_output_data
+
+    def get_output_data(self) -> BlockOutputData:
+        """Get the output data from the state for the current output slot.
+
+        Use `[...]` operator to obtain block wrapper with the same state, but different
+        selected output.
+
+        Returns:
+            Output data for the current output.
+
+        """
+        assert self.state.fit_output_values is not None
+        return self.state.fit_output_values[self.get_output_slot()]
+
+    def __getitem__(self, output_name: str) -> 'EagerBlockWrapper':
+        """Get the eager block wrapper of the same block for the different output name.
+
+        Args:
+            output_name: Name of output to select.
+
+        Returns:
+            New block wrapper for the block with the `output_name` output.
+
+        """
+        eager_block = EagerBlockWrapper(self.block, self.executor, output_name=output_name)
+        eager_block.state = self.state
+        return eager_block
+

--- a/bosk/pipeline/builder/__init__.py
+++ b/bosk/pipeline/builder/__init__.py
@@ -3,9 +3,12 @@
 """
 from .base import BasePipelineBuilder
 from .functional import FunctionalBlockWrapper, FunctionalPipelineBuilder
+from .eager import EagerBlockWrapper, EagerPipelineBuilder
 
 __all__ = [
     "BasePipelineBuilder",
     "FunctionalBlockWrapper",
     "FunctionalPipelineBuilder",
+    "EagerBlockWrapper",
+    "EagerPipelineBuilder",
 ]

--- a/bosk/pipeline/builder/eager.py
+++ b/bosk/pipeline/builder/eager.py
@@ -1,0 +1,85 @@
+from ...executor.block import BaseBlockExecutor, InputSlotToDataMapping
+from ...block.eager import EagerBlockWrapper
+from ...block.base import BaseBlock, BaseInputBlock
+from ...data import BaseData
+from .functional import FunctionalPipelineBuilder, BaseBlockClassRepository, Connection
+from typing import Optional, Callable
+
+
+class EagerPipelineBuilder(FunctionalPipelineBuilder):
+    """Pipeline builder with eager evaluations.
+
+    The builder executes each block at the moment when inputs are passed to its placeholder.
+
+    Args:
+        block_executor: Block executor, which will be applied to blocks to calculate outputs.
+        block_repo: Block class repository for resolving blocks by their names.
+                    Default is zoo scope repository, which means that
+                    all blocks defined in :py:mod:`bosk.block.zoo` will be available
+                    (without postfix "Block", for example:
+                    :py:class:`bosk.block.zoo.data_conversion.ArgmaxBlock`
+                    should be accessed as just "Argmax").
+
+    """
+    def __init__(self, block_executor: BaseBlockExecutor,
+                 block_repo: Optional[BaseBlockClassRepository] = None):
+        super().__init__(block_repo)
+        self.block_executor = block_executor
+
+    def _make_placeholder_fn(self, block: BaseBlock) -> Callable[..., EagerBlockWrapper]:
+        """Make a placeholder function for the block.
+
+        Args:
+            block: Block for which a placeholder is needed.
+
+        Returns:
+            Placeholder function that can be applied to other block wrappers or to data.
+            This function will execute the block.
+
+        """
+        def placeholder_fn(*pfn_args, **pfn_kwargs) -> EagerBlockWrapper:
+            """Execute the block with the given arguments.
+
+            Changes the state of the underlying block (applies FIT & TRANSFORM).
+
+            Args:
+                pfn_args: Only one unnamed argument is supported if the block is `BaseInputBlock`.
+                pfn_kwargs: Named arguments can be other blocks wrappers or just data (`BaseData`).
+
+            Returns:
+                Block wrapper.
+
+            """
+            if len(pfn_args) > 0:
+                assert len(pfn_kwargs) == 0, \
+                    'Either unnamed or named arguments can be used, but not at the same time'
+                assert len(pfn_args) == 1, \
+                    'Only one unnamed argument is supported (we can infer name only in this case)'
+                assert isinstance(block, BaseInputBlock)
+                pfn_kwargs = {
+                    block.get_single_input().meta.name: pfn_args[0]
+                }
+            block_input_mapping: InputSlotToDataMapping = dict()
+            for input_name, input_block_wrap_or_data in pfn_kwargs.items():
+                block_input = block.slots.inputs[input_name]
+                if isinstance(input_block_wrap_or_data, EagerBlockWrapper):
+                    self._connections.append(
+                        Connection(
+                            src=input_block_wrap_or_data.get_output_slot(),
+                            dst=block_input,
+                        )
+                    )
+                    block_input_mapping[block_input] = input_block_wrap_or_data.get_output_data()
+                elif isinstance(input_block_wrap_or_data, BaseData):
+                    block_input_mapping[block_input] = input_block_wrap_or_data
+                else:
+                    raise ValueError(
+                        f'Wrong placeholder input type: {type(input_block_wrap_or_data)}'
+                    )
+            eager_block = EagerBlockWrapper(block, executor=self.block_executor)
+            if len(block_input_mapping) > 0:
+                eager_block.execute(block_input_mapping)
+            return eager_block
+
+        return placeholder_fn
+

--- a/examples/pipeline/eager/simple.py
+++ b/examples/pipeline/eager/simple.py
@@ -1,7 +1,6 @@
 """Example of Eager evaluation: applying fit and transform stages during pipeline construnction.
 
 """
-import json
 from bosk.data import CPUData
 from bosk.stages import Stage
 
@@ -9,100 +8,11 @@ import numpy as np
 
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
-
-from bosk.executor.block import (
-    BaseBlockExecutor,
-    DefaultBlockExecutor,
-    InputSlotToDataMapping,
-    BlockOutputData,
-    BaseData,
-)
-from bosk.block.base import BaseInputBlock
-from bosk.executor.recursive import RecursiveExecutor
-
 from sklearn.metrics import roc_auc_score
-from bosk.block import BaseBlock
 
-from bosk.block.functional import FunctionalBlockWrapper
-from bosk.pipeline.builder.functional import FunctionalPipelineBuilder, BaseBlockClassRepository
-from bosk.pipeline.connection import Connection
-
-from typing import Callable, Optional, Mapping
-
-
-class EagerBlockWrapper(FunctionalBlockWrapper):
-    def __init__(self, block: BaseBlock, executor: BaseBlockExecutor,
-                 output_name: Optional[str] = None):
-        super().__init__(block, output_name=output_name)
-        self.executor = executor
-        self.fit_output_values: Optional[Mapping[str, BaseData]] = None
-
-    def execute(self, block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
-        """Execute the underlying block with the given inputs and store in the wrapper state.
-
-        Args:
-            inputs: Block inputs.
-
-        """
-        assert self.fit_output_values is None, 'Cannot fit the eager block twice'
-        block_output_data = self.executor.execute_block(
-            stage=Stage.FIT,
-            block=self.block,
-            block_input_mapping=block_input_mapping,
-        )
-        self.fit_output_values = block_output_data
-        return block_output_data
-
-    def get_output_data(self) -> BlockOutputData:
-        assert self.fit_output_values is not None
-        return self.fit_output_values[self.get_output_slot()]
-
-    def __getitem__(self, output_name: str) -> 'EagerBlockWrapper':
-        eager_block = EagerBlockWrapper(self.block, output_name=output_name)
-        eager_block.fit_output_values = self.fit_output_values
-        return eager_block
-
-
-class EagerPipelineBuilder(FunctionalPipelineBuilder):
-    def __init__(self, block_executor: BaseBlockExecutor,
-                 block_repo: Optional[BaseBlockClassRepository] = None):
-        super().__init__(block_repo)
-        self.block_executor = block_executor
-
-    def _make_placeholder_fn(self, block: BaseBlock) -> Callable[..., EagerBlockWrapper]:
-        def placeholder_fn(*pfn_args, **pfn_kwargs) -> EagerBlockWrapper:
-            if len(pfn_args) > 0:
-                assert len(pfn_kwargs) == 0, \
-                    'Either unnamed or named arguments can be used, but not at the same time'
-                assert len(pfn_args) == 1, \
-                    'Only one unnamed argument is supported (we can infer name only in this case)'
-                assert isinstance(block, BaseInputBlock)
-                pfn_kwargs = {
-                    block.get_single_input().meta.name: pfn_args[0]
-                }
-            block_input_mapping: InputSlotToDataMapping = dict()
-            for input_name, input_block_wrapper_or_data in pfn_kwargs.items():
-                block_input = block.slots.inputs[input_name]
-                if isinstance(input_block_wrapper_or_data, EagerBlockWrapper):
-                    self._connections.append(
-                        Connection(
-                            src=input_block_wrapper_or_data.get_output_slot(),
-                            dst=block_input,
-                        )
-                    )
-                    block_input_mapping[block_input] = input_block_wrapper_or_data.get_output_data()
-                elif isinstance(input_block_wrapper_or_data, BaseData):
-                    block_input_mapping[block_input] = input_block_wrapper_or_data
-                else:
-                    raise ValueError(
-                        f'Wrong placeholder input type: {type(input_block_wrapper_or_data)}'
-                    )
-            eager_block = EagerBlockWrapper(block, executor=self.block_executor)
-            if len(block_input_mapping) > 0:
-                eager_block.execute(block_input_mapping)
-            return eager_block
-
-        return placeholder_fn
+from bosk.executor.block import DefaultBlockExecutor
+from bosk.executor.recursive import RecursiveExecutor
+from bosk.pipeline.builder.eager import EagerPipelineBuilder
 
 
 def main():
@@ -165,7 +75,6 @@ def main():
     test_result = transform_executor({'X': CPUData(test_X)})
     print("  Train ROC-AUC:", roc_auc_score(train_y, train_result['probas'].data[:, 1]))
     print("  Test ROC-AUC:", roc_auc_score(test_y, test_result['probas'].data[:, 1]))
-
 
 
 if __name__ == "__main__":

--- a/examples/pipeline/eager/simple.py
+++ b/examples/pipeline/eager/simple.py
@@ -1,0 +1,172 @@
+"""Example of Eager evaluation: applying fit and transform stages during pipeline construnction.
+
+"""
+import json
+from bosk.data import CPUData
+from bosk.stages import Stage
+
+import numpy as np
+
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
+from bosk.executor.block import (
+    BaseBlockExecutor,
+    DefaultBlockExecutor,
+    InputSlotToDataMapping,
+    BlockOutputData,
+    BaseData,
+)
+from bosk.block.base import BaseInputBlock
+from bosk.executor.recursive import RecursiveExecutor
+
+from sklearn.metrics import roc_auc_score
+from bosk.block import BaseBlock
+
+from bosk.block.functional import FunctionalBlockWrapper
+from bosk.pipeline.builder.functional import FunctionalPipelineBuilder, BaseBlockClassRepository
+from bosk.pipeline.connection import Connection
+
+from typing import Callable, Optional, Mapping
+
+
+class EagerBlockWrapper(FunctionalBlockWrapper):
+    def __init__(self, block: BaseBlock, executor: BaseBlockExecutor,
+                 output_name: Optional[str] = None):
+        super().__init__(block, output_name=output_name)
+        self.executor = executor
+        self.fit_output_values: Optional[Mapping[str, BaseData]] = None
+
+    def execute(self, block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
+        """Execute the underlying block with the given inputs and store in the wrapper state.
+
+        Args:
+            inputs: Block inputs.
+
+        """
+        assert self.fit_output_values is None, 'Cannot fit the eager block twice'
+        block_output_data = self.executor.execute_block(
+            stage=Stage.FIT,
+            block=self.block,
+            block_input_mapping=block_input_mapping,
+        )
+        self.fit_output_values = block_output_data
+        return block_output_data
+
+    def get_output_data(self) -> BlockOutputData:
+        assert self.fit_output_values is not None
+        return self.fit_output_values[self.get_output_slot()]
+
+    def __getitem__(self, output_name: str) -> 'EagerBlockWrapper':
+        eager_block = EagerBlockWrapper(self.block, output_name=output_name)
+        eager_block.fit_output_values = self.fit_output_values
+        return eager_block
+
+
+class EagerPipelineBuilder(FunctionalPipelineBuilder):
+    def __init__(self, block_executor: BaseBlockExecutor,
+                 block_repo: Optional[BaseBlockClassRepository] = None):
+        super().__init__(block_repo)
+        self.block_executor = block_executor
+
+    def _make_placeholder_fn(self, block: BaseBlock) -> Callable[..., EagerBlockWrapper]:
+        def placeholder_fn(*pfn_args, **pfn_kwargs) -> EagerBlockWrapper:
+            if len(pfn_args) > 0:
+                assert len(pfn_kwargs) == 0, \
+                    'Either unnamed or named arguments can be used, but not at the same time'
+                assert len(pfn_args) == 1, \
+                    'Only one unnamed argument is supported (we can infer name only in this case)'
+                assert isinstance(block, BaseInputBlock)
+                pfn_kwargs = {
+                    block.get_single_input().meta.name: pfn_args[0]
+                }
+            block_input_mapping: InputSlotToDataMapping = dict()
+            for input_name, input_block_wrapper_or_data in pfn_kwargs.items():
+                block_input = block.slots.inputs[input_name]
+                if isinstance(input_block_wrapper_or_data, EagerBlockWrapper):
+                    self._connections.append(
+                        Connection(
+                            src=input_block_wrapper_or_data.get_output_slot(),
+                            dst=block_input,
+                        )
+                    )
+                    block_input_mapping[block_input] = input_block_wrapper_or_data.get_output_data()
+                elif isinstance(input_block_wrapper_or_data, BaseData):
+                    block_input_mapping[block_input] = input_block_wrapper_or_data
+                else:
+                    raise ValueError(
+                        f'Wrong placeholder input type: {type(input_block_wrapper_or_data)}'
+                    )
+            eager_block = EagerBlockWrapper(block, executor=self.block_executor)
+            if len(block_input_mapping) > 0:
+                eager_block.execute(block_input_mapping)
+            return eager_block
+
+        return placeholder_fn
+
+
+def main():
+    # prepare data first
+    all_X, all_y = load_breast_cancer(return_X_y=True)
+    train_X, test_X, train_y, test_y = train_test_split(all_X, all_y, test_size=0.2, random_state=42)
+
+    executor_cls = RecursiveExecutor
+    block_executor = DefaultBlockExecutor()
+    forest_params = dict()
+
+    b = EagerPipelineBuilder(block_executor)
+    X, y = b.Input()(CPUData(train_X)), b.TargetInput()(CPUData(train_y))
+    # alternative ways to define input blocks:
+    # X, y = b.Input()(X=CPUData(train_X)), b.TargetInput()(y=CPUData(train_y))
+    # or without input data:
+    # X, y = b.Input()(), b.TargetInput()()
+    # X.execute({X.block.get_single_input(): CPUData(train_X)})
+    # y.execute({y.block.get_single_input(): CPUData(train_y)})
+
+    rf_1 = b.RFC(random_state=42, **forest_params)(X=X, y=y)
+    et_1 = b.ETC(random_state=42, **forest_params)(X=X, y=y)
+    concat_1 = b.Concat(['X', 'rf_1', 'et_1'])(X=X, rf_1=rf_1, et_1=et_1)
+    rf_2 = b.RFC(random_state=42, **forest_params)(X=concat_1, y=y)
+    et_2 = b.ETC(random_state=42, **forest_params)(X=concat_1, y=y)
+    concat_2 = b.Concat(['X', 'rf_2', 'et_2'])(X=X, rf_2=rf_2, et_2=et_2)
+    rf_3 = b.RFC(random_state=42, **forest_params)(X=concat_2, y=y)
+    et_3 = b.ETC(random_state=42, **forest_params)(X=concat_2, y=y)
+    stack_3 = b.Stack(['rf_3', 'et_3'], axis=1)(rf_3=rf_3, et_3=et_3)
+    average_3 = b.Average(axis=1)(X=stack_3)
+    argmax_3 = b.Argmax(axis=1)(X=average_3)
+
+    rf_1_roc_auc = b.RocAuc()(gt_y=y, pred_probas=rf_1)
+    roc_auc = b.RocAuc()(gt_y=y, pred_probas=average_3)
+
+    fit_executor = executor_cls(
+        b.build(
+            {'X': X, 'y': y},
+            {'probas': average_3, 'rf_1_roc-auc': rf_1_roc_auc, 'roc-auc': roc_auc}
+        ),
+        stage=Stage.FIT,
+        inputs=['X', 'y'],
+        outputs=['probas', 'rf_1_roc-auc', 'roc-auc'],
+    )
+    transform_executor = executor_cls(
+        b.build(
+            {'X': X, 'y': y},
+            {'probas': average_3, 'labels': argmax_3}
+        ),
+        stage=Stage.TRANSFORM,
+        inputs=['X'],
+        outputs=['probas', 'labels'],
+    )
+
+    train_result = transform_executor({'X': CPUData(train_X)})
+    print(
+        "  Fit probas == probas on train:",
+        np.allclose(average_3.get_output_data().data, train_result['probas'].data)
+    )
+    test_result = transform_executor({'X': CPUData(test_X)})
+    print("  Train ROC-AUC:", roc_auc_score(train_y, train_result['probas'].data[:, 1]))
+    print("  Test ROC-AUC:", roc_auc_score(test_y, test_result['probas'].data[:, 1]))
+
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pipelines/eager_test.py
+++ b/tests/pipelines/eager_test.py
@@ -1,0 +1,76 @@
+"""Eager evaluations tests."""
+
+from typing import Dict, Optional, Sequence, Tuple
+from bosk.pipeline.base import BasePipeline
+from bosk.data import BaseData, CPUData
+from bosk.executor.block import DefaultBlockExecutor
+from bosk.executor.recursive import RecursiveExecutor
+from bosk.stages import Stage
+from bosk.pipeline.builder.eager import EagerPipelineBuilder
+from ..utility import fit_pipeline, log_test_name
+from sklearn.datasets import make_moons
+from sklearn.model_selection import train_test_split
+import numpy as np
+import logging
+
+
+class EagerEvaluationTest:
+    """Test case of the basic deep forest constructed with eager evaluations."""
+
+    random_seed = 42
+    executor_cls = RecursiveExecutor
+
+    def eager_fit_transform_test(self):
+        all_X, all_y = make_moons(noise=0.5, random_state=self.random_seed)
+        train_X, test_X, train_y, test_y = train_test_split(
+            all_X,
+            all_y,
+            test_size=0.2,
+            random_state=self.random_seed
+        )
+
+        block_executor = DefaultBlockExecutor()
+        b = EagerPipelineBuilder(block_executor)
+        X, y = b.Input()(CPUData(train_X)), b.TargetInput()(CPUData(train_y))
+        forest_params = dict(n_estimators=3, max_depth=2)
+
+        rf_1 = b.RFC(random_state=self.random_seed, **forest_params)(X=X, y=y)
+        et_1 = b.ETC(random_state=self.random_seed, **forest_params)(X=X, y=y)
+        concat_1 = b.Concat(['X', 'rf_1', 'et_1'])(X=X, rf_1=rf_1, et_1=et_1)
+        rf_2 = b.RFC(random_state=self.random_seed, **forest_params)(X=concat_1, y=y)
+        et_2 = b.ETC(random_state=self.random_seed, **forest_params)(X=concat_1, y=y)
+        concat_2 = b.Concat(['X', 'rf_2', 'et_2'])(X=X, rf_2=rf_2, et_2=et_2)
+        rf_3 = b.RFC(random_state=self.random_seed, **forest_params)(X=concat_2, y=y)
+        et_3 = b.ETC(random_state=self.random_seed, **forest_params)(X=concat_2, y=y)
+        stack_3 = b.Stack(['rf_3', 'et_3'], axis=1)(rf_3=rf_3, et_3=et_3)
+        average_3 = b.Average(axis=1)(X=stack_3)
+        argmax_3 = b.Argmax(axis=1)(X=average_3)
+
+        rf_1_roc_auc = b.RocAuc()(gt_y=y, pred_probas=rf_1)
+        roc_auc = b.RocAuc()(gt_y=y, pred_probas=average_3)
+
+        eager_probas = average_3.get_output_data().data
+
+        fit_executor = self.executor_cls(
+            b.build(
+                {'X': X, 'y': y},
+                {'probas': average_3, 'rf_1_roc-auc': rf_1_roc_auc, 'roc-auc': roc_auc}
+            ),
+            stage=Stage.FIT,
+            inputs=['X', 'y'],
+            outputs=['probas', 'rf_1_roc-auc', 'roc-auc'],
+        )
+        transform_executor = self.executor_cls(
+            b.build(
+                {'X': X, 'y': y},
+                {'probas': average_3, 'labels': argmax_3}
+            ),
+            stage=Stage.TRANSFORM,
+            inputs=['X'],
+            outputs=['probas', 'labels'],
+        )
+
+        train_result = transform_executor({'X': CPUData(train_X)})
+        assert np.allclose(eager_probas, train_result['probas'].data), \
+                "Probabilities obtained at pipeline construction should match the predicted"
+


### PR DESCRIPTION
Eager evaluations support is implemented by:

- new pipeline builder, derived from the `FunctionalPipelineBuilder`;
- new functional block wrapper, derived from the `FunctionalBlockWrapper`.

Each block is executed at a time when arguments are passed to its placeholder function. The execution is done inside the new functional block wrapper `EagerBlockWrapper`, but is initiated by placeholder returned by the `EagerPipelineBuilder`.

Alternatively, each block can be re-evaluated by calling state changing method `EagerBlockWrapper.execute(...)`.

For convenience data (`BaseData`) also can be passed directly to the placeholder as inputs to execute the block.