### PR TITLE
Fix compatibility issues and improve usability

### DIFF
--- a/bosk/block/auto.py
+++ b/bosk/block/auto.py
@@ -57,7 +57,8 @@ class FitTransformClass(Protocol):
 def auto_block(_implicit_cls=None,  # noqa: C901
                execution_props: Optional[BlockExecutionProperties] = None,
                random_state_field: Optional[str] = 'random_state',
-               auto_state: bool = False):
+               auto_state: bool = False,
+               fit_argnames: Optional[set] = None):
     """Decorator for conversion from a fit-transform class into a block.
 
     Args:
@@ -75,6 +76,7 @@ def auto_block(_implicit_cls=None,  # noqa: C901
         Block wrapping function.
 
     """
+    default_fit_argnames = fit_argnames
     def _auto_block_impl(cls: Type[FitTransformClass]) -> Type[BaseBlock]:
         """Make auto block wrapper instance.
 
@@ -85,7 +87,10 @@ def auto_block(_implicit_cls=None,  # noqa: C901
             Block class.
 
         """
-        fit_argnames = set(cls.fit.__code__.co_varnames[1:cls.fit.__code__.co_argcount])
+        if default_fit_argnames is None:
+            fit_argnames = set(cls.fit.__code__.co_varnames[1:cls.fit.__code__.co_argcount])
+        else:
+            fit_argnames = default_fit_argnames
         transform_argnames = set(cls.transform.__code__.co_varnames[1:cls.transform.__code__.co_argcount])
 
         @wraps(cls, updated=())

--- a/bosk/block/base.py
+++ b/bosk/block/base.py
@@ -266,6 +266,16 @@ class BaseBlock(ABC):
             raise NoDefaultBlockOutputError(self)
         return self.slots.outputs[default_output]
 
+    def get_single_input(self) -> BlockInputSlot:
+        """Get the single block input slot.
+
+        Returns:
+            The block input slot.
+        """
+        if len(self.slots.inputs) != 1:
+            raise MultipleBlockInputsError(self)
+        return next(iter(self.slots.inputs.values()))
+
 
 class BaseInputBlock(BaseBlock, metaclass=ABCMeta):
     """Base input block. It is guaranteed that is has a single input and some name.
@@ -287,16 +297,6 @@ class BaseInputBlock(BaseBlock, metaclass=ABCMeta):
         Returns:
             The block instance name.
         """
-
-    def get_single_input(self) -> BlockInputSlot:
-        """Get the single block input slot.
-
-        Returns:
-            The block input slot.
-        """
-        if len(self.slots.inputs) != 1:
-            raise MultipleBlockInputsError(self)
-        return next(iter(self.slots.inputs.values()))
 
 
 class BaseOutputBlock(BaseBlock, metaclass=ABCMeta):

--- a/bosk/block/eager.py
+++ b/bosk/block/eager.py
@@ -1,3 +1,4 @@
+import numpy as np
 from ..executor.block import BaseBlockExecutor, InputSlotToDataMapping
 from ..block.base import BaseBlock, BlockOutputData
 from ..data import BaseData
@@ -73,8 +74,23 @@ class EagerBlockWrapper(FunctionalBlockWrapper):
             Output data for the current output.
 
         """
-        assert self.state.fit_output_values is not None
+        assert self.state.fit_output_values is not None, \
+            'The block should be executed first to get a result. ' \
+            'Check that the inputs are correctly passed to the block.'
         return self.state.fit_output_values[self.get_output_slot()]
+
+    @property
+    def data(self) -> np.ndarray:
+        """Return the output data as a NumPy array.
+
+        This property provides convenient access to the block's output data as a NumPy array,
+        assuming the output is of a numerical type that can be represented by NumPy arrays.
+        It retrieves the data from the internal state and returns it.
+
+        Returns:
+            The output data as a NumPy array.
+        """
+        return self.get_output_data().to_cpu().data
 
     def __getitem__(self, output_name: str) -> 'EagerBlockWrapper':
         """Get the eager block wrapper of the same block for the different output name.

--- a/bosk/block/zoo/data_conversion/__init__.py
+++ b/bosk/block/zoo/data_conversion/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 
-from ...base import BaseBlock, BlockInputData, TransformOutputData
+from ...base import BaseBlock, BlockInputData, BlockInputSlot, TransformOutputData
 from ...placeholder import PlaceholderMixin
 from ...meta import BlockMeta, DynamicBlockMetaStub, make_simple_meta, BlockExecutionProperties
 from ....data import BaseData, GPUData, CPUData, jnp

--- a/bosk/block/zoo/models/classification/__init__.py
+++ b/bosk/block/zoo/models/classification/__init__.py
@@ -1,5 +1,3 @@
-from catboost import CatBoostClassifier as _CatBoostClassifier
-from xgboost import XGBClassifier as _XGBClassifier
 from sklearn.ensemble import (
     RandomForestClassifier,
     ExtraTreesClassifier,
@@ -38,7 +36,7 @@ __all__ = [
 ]
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y', 'sample_weight'})
 class RFC(RandomForestClassifier):
     """Random Forest Classifier.
 
@@ -66,7 +64,7 @@ class RFC(RandomForestClassifier):
         return CPUData(self.predict_proba(X))
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y', 'sample_weight'})
 class ETC(ExtraTreesClassifier):
     """Extremely Randomized Trees Classifier.
 
@@ -94,69 +92,83 @@ class ETC(ExtraTreesClassifier):
         return CPUData(self.predict_proba(X))
 
 
-@auto_block(execution_props=BlockExecutionProperties())
-class CatBoostClassifier(_CatBoostClassifier):
-    """CatBoost Classifier.
+try:
+    from catboost import CatBoostClassifier as _CatBoostClassifier
 
-    Input slots
-    -----------
+    @auto_block(execution_props=BlockExecutionProperties())
+    class CatBoostClassifier(_CatBoostClassifier):
+        """CatBoost Classifier.
 
-    Fit inputs
-    ~~~~~~~~~~
+        Input slots
+        -----------
 
-        - X: Input features.
-        - y: Ground truth labels.
+        Fit inputs
+        ~~~~~~~~~~
 
-    Transform inputs
-    ~~~~~~~~~~~~~~~~
+            - X: Input features.
+            - y: Ground truth labels.
 
-        - X: Input features.
+        Transform inputs
+        ~~~~~~~~~~~~~~~~
 
-    Output slots
-    ------------
+            - X: Input features.
 
-        - output: Predicted probabilities.
+        Output slots
+        ------------
 
-    """
-    def transform(self, X):
-        return CPUData(self.predict_proba(X))
+            - output: Predicted probabilities.
+
+        """
+        def transform(self, X):
+            return CPUData(self.predict_proba(X))
+
+    CatBoostClassifierBlock = CatBoostClassifier
+
+except ModuleNotFoundError:
+    pass
 
 
-@auto_block(execution_props=BlockExecutionProperties())
-class XGBClassifier(_XGBClassifier):
-    """XGBoost Classifier.
+try:
+    from xgboost import XGBClassifier as _XGBClassifier
 
-    Input slots
-    -----------
+    @auto_block(execution_props=BlockExecutionProperties())
+    class XGBClassifier(_XGBClassifier):
+        """XGBoost Classifier.
 
-    Fit inputs
-    ~~~~~~~~~~
+        Input slots
+        -----------
 
-        - X: Input features.
-        - y: Ground truth labels.
+        Fit inputs
+        ~~~~~~~~~~
 
-    Transform inputs
-    ~~~~~~~~~~~~~~~~
+            - X: Input features.
+            - y: Ground truth labels.
 
-        - X: Input features.
+        Transform inputs
+        ~~~~~~~~~~~~~~~~
 
-    Output slots
-    ------------
+            - X: Input features.
 
-        - output: Predicted probabilities.
+        Output slots
+        ------------
 
-    """
-    def fit(self, X, y):
-        super().fit(X, y)
+            - output: Predicted probabilities.
 
-    def transform(self, X):
-        return CPUData(self.predict_proba(X))
+        """
+        def fit(self, X, y):
+            super().fit(X, y)
+
+        def transform(self, X):
+            return CPUData(self.predict_proba(X))
+
+    XGBClassifierBlock = XGBClassifier
+
+except ModuleNotFoundError:
+    pass
 
 
 RFCBlock = RFC
 ETCBlock = ETC
-CatBoostClassifierBlock = CatBoostClassifier
-XGBClassifierBlock = XGBClassifier
 
 
 try:

--- a/bosk/block/zoo/models/classification/ferns.py
+++ b/bosk/block/zoo/models/classification/ferns.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 @partial(jax.jit, static_argnames=('n_ferns', 'fern_size'))
-def make_unary_ferns(xs: jnp.ndarray, n_ferns: int, fern_size: int, key: random.KeyArray):
+def make_unary_ferns(xs: jnp.ndarray, n_ferns: int, fern_size: int, key):
     """Generate indices and threshold values for unary fern.
     An unary fern represents a function that maps x to an integer number:
         x -> [ x[i[0]] >= t[0], ..., x[i[k]] >= t[k] ].
@@ -77,7 +77,7 @@ def apply_unary_ferns(xs: jnp.ndarray, feature_indices, feature_thresholds):
 
 
 @partial(jax.jit, static_argnames=('n_ferns', 'fern_size'))
-def make_binary_ferns(xs: jnp.ndarray, n_ferns: int, fern_size: int, key: random.KeyArray):
+def make_binary_ferns(xs: jnp.ndarray, n_ferns: int, fern_size: int, key):
     """Generate indices and threshold values for unary fern.
     An unary fern represents a function that maps x to an integer number:
         x -> [ x[i[0]] >= x[j[0]], ..., x[i[k]] >= x[j[k]] ].

--- a/bosk/block/zoo/models/classification/mgs_ferns.py
+++ b/bosk/block/zoo/models/classification/mgs_ferns.py
@@ -31,7 +31,7 @@ def make_window_unary_ferns(xs: jnp.ndarray,
                             window_size: int,
                             n_ferns: int,
                             fern_size: int,
-                            key: random.KeyArray):
+                            key):
     """Generate indices and threshold values for unary fern that is applied to a sliding window.
     The sliding window captures all channels simultaneously.
 
@@ -106,7 +106,7 @@ def make_window_binary_ferns(n_channels: int,
                              window_size: int,
                              n_ferns: int,
                              fern_size: int,
-                             key: random.KeyArray):
+                             key):
     """Generate pair indices for binary fern which is applied to a sliding window.
     The sliding window captures all channels simultaneously.
 

--- a/bosk/block/zoo/models/regression/__init__.py
+++ b/bosk/block/zoo/models/regression/__init__.py
@@ -23,13 +23,13 @@ __all__ = [
 ]
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y', 'sample_weight'})
 class RFR(RandomForestRegressor):
     def transform(self, X):
         return CPUData(self.predict(X))
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y', 'sample_weight'})
 class ETR(ExtraTreesRegressor):
     def transform(self, X):
         return CPUData(self.predict(X))

--- a/bosk/exceptions.py
+++ b/bosk/exceptions.py
@@ -39,3 +39,17 @@ class MultipleBlockOutputsError(MultipleBlockSlotsError):
     """
     def __init__(self, block):
         super().__init__(block, slot='output')
+
+
+class BlockReuseError(Exception):
+    """Raised when the same block is tried to be reused (used twice in the pipeline).
+
+    For example, when using the `FunctionalPipelineBuilder`, "calling" the same block
+    twice leads to this exception.
+    """
+    def __init__(self, block):
+        super().__init__(
+            f'The block {block!r} is tried to be reused, which is prohibited. ' \
+            'If it is intended, please implement separate blocks, one for each use. '
+            'If the blocks have to share some state, return it from the first block and consume in the second block.'
+        )


### PR DESCRIPTION
**Fixed the following issues:**

- Modern scikit-learn estimators cannot be inspected, i.e. getting correct method argument names is impossible for now. Solution: add optional `fit_argnames` to `auto_block`;
- Wrapped scikit-learn blocks `fit_argnames` have been provided;
- JAX `random.KeyArray` type annotations have been deleted since it was deprecated (and deleted) in the recent versions of the JAX;
- CatBoost and XGBoost imports have been wrapped with try-except in order to avoid import errors caused by third-party modules. For example, currently CatBoost fails to build for Python 3.13.2;
- Block reuse in Functional and Eager pipeline builders now raise `BlockReuseError`.

Also:

- Each block has `get_single_input` method, which can raise exception if there are more than one input;
- Eager block wrapper now has `.data` property for convenience (previously the only way to get execution result was `block.get_output_data().to_cpu().data`);
- Each placeholder function in Functional and Eager pipeline builders now has auto-generated documentation and signature (correctly named keyword arguments), which should help to write code in dynamic environments, e.g. in Jupyter notebooks.