### PR TITLE
Add Shared Blocks allowing to predict with previously trained blocks

### DIFF
--- a/bosk/auto/metrics.py
+++ b/bosk/auto/metrics.py
@@ -56,6 +56,6 @@ class MetricsEvaluator:
             A mapping (dictionary) of metric names to average metric values.
         """
         return {
-            k: np.mean(v)
+            k: float(np.mean(v))
             for k, v in self.results.items()
         }

--- a/bosk/block/auto.py
+++ b/bosk/block/auto.py
@@ -71,6 +71,8 @@ def auto_block(_implicit_cls=None,  # noqa: C901
             the `set_random_state` method, it won't be redefined.
         auto_state: Automatically implement `__getstate__` and `__setstate__` methods.
                     These methods are required for serialization.
+        fit_argnames: Argument names for the `fit` method.
+                     If None, argument names will be inferred automatically.
 
     Returns:
         Block wrapping function.

--- a/bosk/block/auto.py
+++ b/bosk/block/auto.py
@@ -114,7 +114,7 @@ def auto_block(_implicit_cls=None,  # noqa: C901
                 execution_props=execution_props
             )
 
-            @wraps(cls.__init__)
+            @wraps(cls.__init__)  # type: ignore
             def __init__(self, *args, **kwargs):
                 super().__init__()
                 self.__instance = cls(*args, **kwargs)

--- a/bosk/block/base.py
+++ b/bosk/block/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from numpy.random import Generator
-from typing import Mapping, Set, TypeVar, Optional, Union
+from typing import Dict, Mapping, Set, TypeVar, Optional, Union
 
 from .meta import BaseSlotMeta, BlockMeta, InputSlotMeta, OutputSlotMeta
 from ..data import BaseData
@@ -116,13 +116,13 @@ class BlockSlots:
     groups: Set[BlockGroup] = field(default_factory=lambda: set())
 
 
-BlockInputData = Mapping[str, BaseData]
+BlockInputData = Dict[str, BaseData]
 """Block input values container data type.
 
 It is indexed by input slot names.
 """
 
-TransformOutputData = Mapping[str, BaseData]
+TransformOutputData = Dict[str, BaseData]
 """Block transform output values container data type.
 
 It is indexed by output slot names.

--- a/bosk/block/eager.py
+++ b/bosk/block/eager.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ..executor.block import BaseBlockExecutor, InputSlotToDataMapping
-from ..block.base import BaseBlock, BlockOutputData
+from ..block.base import BaseBlock, BlockOutputData, BlockOutputSlot
 from ..data import BaseData
 from ..stages import Stage
 from .functional import FunctionalBlockWrapper
@@ -19,7 +19,7 @@ class EagerBlockState:
 
     """
     def __init__(self):
-        self.fit_output_values: Optional[Mapping[str, BaseData]] = None
+        self.fit_output_values: Optional[Mapping[BlockOutputSlot, BaseData]] = None
 
 
 class EagerBlockWrapper(FunctionalBlockWrapper):
@@ -45,6 +45,13 @@ class EagerBlockWrapper(FunctionalBlockWrapper):
         super().__init__(block, output_name=output_name)
         self.executor = executor
         self.state = EagerBlockState()
+
+    def set_block(self, block):
+        super().set_block(block)
+        self.state.fit_output_values = {
+            self.block.slots.outputs[key.meta.name]: value
+            for key, value in self.state.fit_output_values.items()
+        }
 
     def execute(self, block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
         """Execute the underlying block with the given inputs and store the result in the state.

--- a/bosk/block/eager.py
+++ b/bosk/block/eager.py
@@ -71,7 +71,7 @@ class EagerBlockWrapper(FunctionalBlockWrapper):
         self.state.fit_output_values = block_output_data
         return block_output_data
 
-    def get_output_data(self) -> BlockOutputData:
+    def get_output_data(self) -> BaseData:
         """Get the output data from the state for the current output slot.
 
         Use `[...]` operator to obtain block wrapper with the same state, but different

--- a/bosk/block/functional.py
+++ b/bosk/block/functional.py
@@ -44,6 +44,9 @@ class FunctionalBlockWrapper:
         self.block = block
         self.output_name = output_name
 
+    def set_block(self, block):
+        self.block = block
+
     def get_input_slot(self, slot_name: Optional[str] = None) -> BlockInputSlot:
         """Get block input slot by name.
 
@@ -86,10 +89,11 @@ class FunctionalBlockWrapper:
 
         """
         if self.output_name is None:
-            if self.block.default_output is None:
-                raise RuntimeError('Block has more than one output and the default is not specified')
-            else:
-                return self.block.slots.outputs[self.block.default_output]
+            # if self.block.default_output is None:
+            #     raise RuntimeError('Block has more than one output and the default is not specified')
+            # else:
+            #     return self.block.slots.outputs[self.block.default_output]
+            return self.block.get_default_output()
         return self.block.slots.outputs[self.output_name]
 
     def __getitem__(self, output_name: str) -> 'FunctionalBlockWrapper':

--- a/bosk/block/zoo/metrics/__init__.py
+++ b/bosk/block/zoo/metrics/__init__.py
@@ -72,7 +72,7 @@ class RocAuc(PlaceholderMixin, BaseBlock):
         execution_props=BlockExecutionProperties()
     )
 
-    @wraps(roc_auc_score)
+    @wraps(roc_auc_score)  # type: ignore
     def __init__(self, **kwargs):
         super().__init__()
         self.roc_auc_score_kwargs = kwargs
@@ -256,7 +256,7 @@ class F1Score(PlaceholderMixin, BaseBlock):
         execution_props=BlockExecutionProperties()
     )
 
-    @wraps(f1_score)
+    @wraps(f1_score)  # type: ignore
     def __init__(self, **kwargs):
         super().__init__()
         self.f1_score_kwargs = kwargs
@@ -323,7 +323,7 @@ class R2Score(PlaceholderMixin, BaseBlock):
         execution_props=BlockExecutionProperties()
     )
 
-    @wraps(r2_score)
+    @wraps(r2_score)  # type: ignore
     def __init__(self, **kwargs):
         super().__init__()
         self.r2_score_kwargs = kwargs

--- a/bosk/block/zoo/routing/__init__.py
+++ b/bosk/block/zoo/routing/__init__.py
@@ -8,7 +8,7 @@ on some subset of the data.
 """
 from .cs import CS, CSJoin, CSFilter, CSBlock, CSJoinBlock, CSFilterBlock
 from .cv import CVTrainIndices, SubsetTrainWrapper, CVTrainIndicesBlock, SubsetTrainWrapperBlock
-from .shared import Shared
+from .shared import NaiveShared, SharedProducer, SharedConsumer
 
 
 __all__ = [
@@ -17,7 +17,9 @@ __all__ = [
     "CSFilter",
     "CVTrainIndices",
     "SubsetTrainWrapper",
-    "Shared",
+    "NaiveShared",
+    "SharedProducer",
+    "SharedConsumer",
     # for backward compatibility:
     "CSBlock",
     "CSJoinBlock",

--- a/bosk/block/zoo/routing/__init__.py
+++ b/bosk/block/zoo/routing/__init__.py
@@ -8,6 +8,7 @@ on some subset of the data.
 """
 from .cs import CS, CSJoin, CSFilter, CSBlock, CSJoinBlock, CSFilterBlock
 from .cv import CVTrainIndices, SubsetTrainWrapper, CVTrainIndicesBlock, SubsetTrainWrapperBlock
+from .shared import Shared
 
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "CSFilter",
     "CVTrainIndices",
     "SubsetTrainWrapper",
+    "Shared",
     # for backward compatibility:
     "CSBlock",
     "CSJoinBlock",

--- a/bosk/block/zoo/routing/shared.py
+++ b/bosk/block/zoo/routing/shared.py
@@ -1,3 +1,4 @@
+from bosk.data import CPUData
 import numpy as np
 from typing import Optional, Union
 
@@ -137,7 +138,7 @@ class SharedProducer(PlaceholderMixin, BaseBlock):
 
     def transform(self, inputs: BlockInputData) -> TransformOutputData:
         return self.block.transform(inputs) | {
-            self.output_block_name: self.block
+            self.output_block_name: CPUData(np.array(self.block))
         }
 
     def get_default_output(self):
@@ -214,7 +215,8 @@ class SharedConsumer(PlaceholderMixin, BaseBlock):
     def transform(self, inputs: BlockInputData) -> TransformOutputData:
         if self.input_block_name not in inputs:
             raise BlockInputMissingError(self, self.input_block_name)
-        block = inputs.pop(self.input_block_name)
+        block: BaseBlock = inputs.pop(self.input_block_name).data.item()
+        assert isinstance(block, BaseBlock)
         return block.transform(inputs)
 
     def get_default_output(self):

--- a/bosk/block/zoo/routing/shared.py
+++ b/bosk/block/zoo/routing/shared.py
@@ -1,0 +1,71 @@
+import numpy as np
+from typing import Optional, Union
+
+from ...base import BaseBlock, BlockInputData, TransformOutputData
+from ...placeholder import PlaceholderMixin
+from ...meta import (
+    BlockMeta,
+    DynamicBlockMetaStub,
+)
+
+
+class Shared(PlaceholderMixin, BaseBlock):
+    """Shared Block.
+
+    It wraps a block that has already been trained
+    and allows to apply transform to the other input data.
+
+    Dynamically specifies the meta information.
+
+    Args:
+        block: Wrapped block.
+
+    Input slots
+    -----------
+
+    Fit inputs
+    ~~~~~~~~~~
+
+        The fit step is bypassed.
+
+    Transform inputs
+    ~~~~~~~~~~~~~~~~
+
+        The same as in `block`.
+
+    Output slots
+    ------------
+
+        The same as in `block`.
+
+    Attributes:
+        block: The wrapped block.
+
+    """
+
+    meta: BlockMeta = DynamicBlockMetaStub()
+
+    def __init__(self, block: BaseBlock):
+        self.meta = BlockMeta(
+            inputs=[
+                inp for inp in block.meta.inputs.values()
+                if inp.stages.transform or inp.stages.transform_on_fit
+            ],
+            outputs=[
+                out for out in block.meta.outputs.values()
+            ],
+            execution_props=block.meta.execution_props
+        )
+        self.block = block
+        super().__init__()
+
+    def fit(self, inputs: BlockInputData) -> 'Shared':
+        """The block (wrapper) bypasses the fit step."""
+        # do nothing because the warpped block is already fitted
+        return self
+
+    def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        return self.block.transform(inputs)
+
+    def set_random_state(self, seed: Optional[Union[int, np.random.Generator]]) -> None:
+        return self.block.set_random_state(seed)

--- a/bosk/block/zoo/routing/shared.py
+++ b/bosk/block/zoo/routing/shared.py
@@ -6,8 +6,11 @@ from ...placeholder import PlaceholderMixin
 from ...meta import (
     BlockMeta,
     DynamicBlockMetaStub,
+    InputSlotMeta,
     OutputSlotMeta,
 )
+from ....stages import Stages
+from ....exceptions import BlockInputMissingError
 
 
 class NaiveShared(PlaceholderMixin, BaseBlock):
@@ -116,18 +119,19 @@ class SharedProducer(PlaceholderMixin, BaseBlock):
         self.meta = BlockMeta(
             inputs=[
                 inp for inp in block.meta.inputs.values()
-                if inp.stages.transform or inp.stages.transform_on_fit
             ],
             outputs=[
                 out for out in block.meta.outputs.values()
-            ] + [OutputSlotMeta(output_block_name)],
+            ] + [
+                OutputSlotMeta(output_block_name),
+            ],
             execution_props=block.meta.execution_props
         )
         self.block = block
         self.output_block_name = output_block_name
         super().__init__()
 
-    def fit(self, inputs: BlockInputData) -> 'NaiveShared':
+    def fit(self, inputs: BlockInputData) -> 'SharedProducer':
         self.block.fit(inputs)
         return self
 
@@ -135,6 +139,9 @@ class SharedProducer(PlaceholderMixin, BaseBlock):
         return self.block.transform(inputs) | {
             self.output_block_name: self.block
         }
+
+    def get_default_output(self):
+        return self.slots.outputs[self.block.get_default_output().meta.name]
 
     def set_random_state(self, seed: Optional[Union[int, np.random.Generator]]) -> None:
         return self.block.set_random_state(seed)
@@ -175,11 +182,14 @@ class SharedConsumer(PlaceholderMixin, BaseBlock):
 
     meta: BlockMeta = DynamicBlockMetaStub()
 
-    def __init__(self, producer_meta: BlockMeta, input_block_name: str = 'block'):
+    def __init__(self, producer_meta: BlockMeta, input_block_name: str = 'block',
+                 default_output_name: str = ''):
         self.meta = BlockMeta(
             inputs=[
                 inp for inp in producer_meta.inputs.values()
                 if inp.stages.transform or inp.stages.transform_on_fit
+            ] + [
+                InputSlotMeta(name=input_block_name, stages=Stages(transform_on_fit=True, fit=True)),
             ],
             outputs=[
                 out for out in producer_meta.outputs.values()
@@ -187,17 +197,28 @@ class SharedConsumer(PlaceholderMixin, BaseBlock):
             ],
             execution_props=producer_meta.execution_props
         )
+        if default_output_name not in producer_meta.outputs:
+            raise ValueError(
+                f'{default_output_name=!r} of SharedConsumer should be chosen from `producer_meta.outputs`: ' \
+                f'{list(producer_meta.outputs.keys())!r}'
+            )
         self.input_block_name = input_block_name
+        self.default_output_name = default_output_name
         super().__init__()
 
-    def fit(self, inputs: BlockInputData) -> 'NaiveShared':
+    def fit(self, inputs: BlockInputData) -> 'SharedConsumer':
         """The block (wrapper) bypasses the fit step."""
         # do nothing because the warpped block is already fitted
         return self
 
     def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        if self.input_block_name not in inputs:
+            raise BlockInputMissingError(self, self.input_block_name)
         block = inputs.pop(self.input_block_name)
         return block.transform(inputs)
+
+    def get_default_output(self):
+        return self.slots.outputs[self.default_output_name]
 
     def set_random_state(self, seed: Optional[Union[int, np.random.Generator]]) -> None:
         # SharedProducer owns the block, so it changes the random state

--- a/bosk/block/zoo/routing/shared.py
+++ b/bosk/block/zoo/routing/shared.py
@@ -1,16 +1,21 @@
 import numpy as np
 from typing import Optional, Union
 
-from ...base import BaseBlock, BlockInputData, TransformOutputData
+from ...base import BaseBlock, BlockInputData, BlockOutputSlot, TransformOutputData
 from ...placeholder import PlaceholderMixin
 from ...meta import (
     BlockMeta,
     DynamicBlockMetaStub,
+    OutputSlotMeta,
 )
 
 
-class Shared(PlaceholderMixin, BaseBlock):
-    """Shared Block.
+class NaiveShared(PlaceholderMixin, BaseBlock):
+    """Naive Shared Block.
+
+    **Warning: the wrapped block has to be trained either before the initialization
+    or at least before transform. It is complicated to do so in concurrent environments.**
+    Please consider `SharedProducer` and `SharedConsumer` instead.
 
     It wraps a block that has already been trained
     and allows to apply transform to the other input data.
@@ -59,7 +64,7 @@ class Shared(PlaceholderMixin, BaseBlock):
         self.block = block
         super().__init__()
 
-    def fit(self, inputs: BlockInputData) -> 'Shared':
+    def fit(self, inputs: BlockInputData) -> 'NaiveShared':
         """The block (wrapper) bypasses the fit step."""
         # do nothing because the warpped block is already fitted
         return self
@@ -69,3 +74,134 @@ class Shared(PlaceholderMixin, BaseBlock):
 
     def set_random_state(self, seed: Optional[Union[int, np.random.Generator]]) -> None:
         return self.block.set_random_state(seed)
+
+
+class SharedProducer(PlaceholderMixin, BaseBlock):
+    """Shared Producer Block.
+
+    It wraps a block and returns it at transform.
+    **The wrapped block cannot be used elsewhere in pipeline.**
+
+    Dynamically specifies the meta information.
+
+    Args:
+        block: Wrapped block.
+
+    Input slots
+    -----------
+
+    Fit inputs
+    ~~~~~~~~~~
+
+        The fit step is bypassed.
+
+    Transform inputs
+    ~~~~~~~~~~~~~~~~
+
+        The same as in `block`.
+
+    Output slots
+    ------------
+
+        The same as in `block`.
+
+    Attributes:
+        block: The wrapped block.
+
+    """
+
+    meta: BlockMeta = DynamicBlockMetaStub()
+
+    def __init__(self, block: BaseBlock, output_block_name: str = 'block'):
+        self.meta = BlockMeta(
+            inputs=[
+                inp for inp in block.meta.inputs.values()
+                if inp.stages.transform or inp.stages.transform_on_fit
+            ],
+            outputs=[
+                out for out in block.meta.outputs.values()
+            ] + [OutputSlotMeta(output_block_name)],
+            execution_props=block.meta.execution_props
+        )
+        self.block = block
+        self.output_block_name = output_block_name
+        super().__init__()
+
+    def fit(self, inputs: BlockInputData) -> 'NaiveShared':
+        self.block.fit(inputs)
+        return self
+
+    def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        return self.block.transform(inputs) | {
+            self.output_block_name: self.block
+        }
+
+    def set_random_state(self, seed: Optional[Union[int, np.random.Generator]]) -> None:
+        return self.block.set_random_state(seed)
+
+
+class SharedConsumer(PlaceholderMixin, BaseBlock):
+    """Shared Consumer Block.
+
+    It receives a block as input, as well as the block inputs and returns block's output at transform.
+
+    Dynamically specifies the meta information.
+
+    Args:
+        block: Wrapped block.
+
+    Input slots
+    -----------
+
+    Fit inputs
+    ~~~~~~~~~~
+
+        The fit step is bypassed.
+
+    Transform inputs
+    ~~~~~~~~~~~~~~~~
+
+        The same as in `block`.
+
+    Output slots
+    ------------
+
+        The same as in `block`.
+
+    Attributes:
+        block: The wrapped block.
+
+    """
+
+    meta: BlockMeta = DynamicBlockMetaStub()
+
+    def __init__(self, producer_meta: BlockMeta, input_block_name: str = 'block'):
+        self.meta = BlockMeta(
+            inputs=[
+                inp for inp in producer_meta.inputs.values()
+                if inp.stages.transform or inp.stages.transform_on_fit
+            ],
+            outputs=[
+                out for out in producer_meta.outputs.values()
+                if out.name != input_block_name
+            ],
+            execution_props=producer_meta.execution_props
+        )
+        self.input_block_name = input_block_name
+        super().__init__()
+
+    def fit(self, inputs: BlockInputData) -> 'NaiveShared':
+        """The block (wrapper) bypasses the fit step."""
+        # do nothing because the warpped block is already fitted
+        return self
+
+    def transform(self, inputs: BlockInputData) -> TransformOutputData:
+        block = inputs.pop(self.input_block_name)
+        return block.transform(inputs)
+
+    def set_random_state(self, seed: Optional[Union[int, np.random.Generator]]) -> None:
+        # SharedProducer owns the block, so it changes the random state
+        return
+
+
+NaiveSharedBlock = NaiveShared

--- a/bosk/exceptions.py
+++ b/bosk/exceptions.py
@@ -53,3 +53,12 @@ class BlockReuseError(Exception):
             'If it is intended, please implement separate blocks, one for each use. '
             'If the blocks have to share some state, return it from the first block and consume in the second block.'
         )
+
+
+class BlockInputMissingError(Exception):
+    """Raised when the block is tried to be executed without one of required inputs.
+    """
+    def __init__(self, block, input):
+        super().__init__(
+            f'The block {block!r} is tried to be executed without the input {input!r}.'
+        )

--- a/bosk/executor/block.py
+++ b/bosk/executor/block.py
@@ -6,7 +6,7 @@ are used to evaluate result of each block.
 """
 
 from abc import ABC, abstractmethod
-from typing import Mapping, MutableMapping, Optional, Sequence
+from typing import Dict, Mapping, MutableMapping, Optional, Sequence
 
 from ..data import BaseData, CPUData, GPUData
 from ..stages import Stage
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-InputSlotToDataMapping = Mapping[BlockInputSlot, BaseData]
+InputSlotToDataMapping = Dict[BlockInputSlot, BaseData]
 """Block input slot data mapping.
 
 It is indexed by input slots.
@@ -79,7 +79,7 @@ class GPUBlockExecutor(BaseBlockExecutor):
                       block: BaseBlock,
                       block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
         if stage == Stage.FIT:
-            filtered_block_input_mapping_fit: MutableMapping[str, BaseData] = dict()
+            filtered_block_input_mapping_fit: Dict[str, BaseData] = dict()
             for slot, values in block_input_mapping.items():
                 if slot.meta.stages.fit:
                     if slot.parent_block.meta.execution_props.gpu:
@@ -98,7 +98,7 @@ class GPUBlockExecutor(BaseBlockExecutor):
                             filtered_block_input_mapping_fit[slot.meta.name] = CPUData(values)
             block.fit(filtered_block_input_mapping_fit)
 
-        filtered_block_input_mapping: MutableMapping[str, BaseData] = dict()
+        filtered_block_input_mapping: Dict[str, BaseData] = dict()
         for slot, values in block_input_mapping.items():
             if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit):
                 if slot.parent_block.meta.execution_props.gpu:
@@ -129,7 +129,7 @@ class CPUBlockExecutor(BaseBlockExecutor):
                       block: BaseBlock,
                       block_input_mapping: InputSlotToDataMapping) -> BlockOutputData:
         if stage == Stage.FIT:
-            filtered_block_input_mapping_fit: MutableMapping[str, BaseData] = dict()
+            filtered_block_input_mapping_fit: Dict[str, BaseData] = dict()
             for slot, values in block_input_mapping.items():
                 if slot.meta.stages.fit:
                     if slot.parent_block.meta.execution_props.cpu:
@@ -148,7 +148,7 @@ class CPUBlockExecutor(BaseBlockExecutor):
                             filtered_block_input_mapping_fit[slot.meta.name] = GPUData(values)
             block.fit(filtered_block_input_mapping_fit)
 
-        filtered_block_input_mapping: MutableMapping[str, BaseData] = dict()
+        filtered_block_input_mapping: Dict[str, BaseData] = dict()
         for slot, values in block_input_mapping.items():
             if slot.meta.stages.transform or (stage == Stage.FIT and slot.meta.stages.transform_on_fit):
                 if slot.parent_block.meta.execution_props.cpu:

--- a/bosk/executor/parallel/greedy.py
+++ b/bosk/executor/parallel/greedy.py
@@ -197,7 +197,7 @@ class GreedyParallelExecutor(BaseExecutor):
         return result
 
     def _prepare_inputs(self, block,
-                        input_slot_values: Mapping[BlockInputSlot, BaseData]) -> Mapping[BlockInputSlot, BaseData]:
+                        input_slot_values: Mapping[BlockInputSlot, BaseData]) -> Dict[BlockInputSlot, BaseData]:
         """Prepare the mapping of inputs needed for the block.
 
         Args:

--- a/bosk/painter/graphviz.py
+++ b/bosk/painter/graphviz.py
@@ -107,6 +107,7 @@ class GraphvizPainter(BasePainter):
         self._graph.attr(rankdir=self._rankdir, ranksep=str(self._levels_sep), dpi=str(self._dpi))
         self._graph.render(outfile=output_filename, cleanup=True)
 
+    @property
     def available_formats(self) -> Sequence[str]:
         return gv.FORMATS
 

--- a/bosk/pipeline/builder/eager.py
+++ b/bosk/pipeline/builder/eager.py
@@ -93,7 +93,9 @@ class EagerPipelineBuilder(FunctionalPipelineBuilder):
                     )
             if isinstance(block, SharedConsumer):
                 assert producer_block is not None
-                block_input_mapping[block.slots.inputs[block.input_block_name]] = producer_block.block
+                block_input_mapping[block.slots.inputs[block.input_block_name]] = CPUData(
+                    np.array(producer_block.block)
+                )
             eager_block = EagerBlockWrapper(block, executor=self.block_executor)
             if len(block_input_mapping) > 0:
                 eager_block.execute(block_input_mapping)

--- a/bosk/pipeline/builder/eager.py
+++ b/bosk/pipeline/builder/eager.py
@@ -106,9 +106,13 @@ class EagerPipelineBuilder(FunctionalPipelineBuilder):
         placeholder_fn.__doc__ = f'Execute the block {block} and get the result wrapper.' \
             '\n\n' + ('=' * (25 + len(repr(block)))) + '\n' \
             f'The block {block} documentation:\n\n' + str(inspect.getdoc(block.__class__))
-        placeholder_fn.__signature__ = inspect.Signature([
-            inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY)
-            for name in block.slots.inputs.keys()
-        ])
+        setattr(
+            placeholder_fn,
+            '__signature__',
+            inspect.Signature([
+                inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY)
+                for name in block.slots.inputs.keys()
+            ])
+        )
         return placeholder_fn
 

--- a/bosk/pipeline/builder/eager.py
+++ b/bosk/pipeline/builder/eager.py
@@ -1,8 +1,9 @@
-from ...executor.block import BaseBlockExecutor, InputSlotToDataMapping
+from ...executor.block import BaseBlockExecutor, InputSlotToDataMapping, DefaultBlockExecutor
 from ...block.eager import EagerBlockWrapper
 from ...block.base import BaseBlock, BaseInputBlock
+from ...block.zoo.routing.shared import SharedProducer, SharedConsumer
 from ...data import BaseData, CPUData
-from .functional import FunctionalPipelineBuilder, BaseBlockClassRepository, Connection
+from .functional import FunctionalPipelineBuilder, BaseBlockClassRepository, Connection, PlaceholderFunctionState
 from ...exceptions import BlockReuseError
 from typing import Optional, Callable
 import numpy as np
@@ -24,12 +25,16 @@ class EagerPipelineBuilder(FunctionalPipelineBuilder):
                     should be accessed as just "Argmax").
 
     """
-    def __init__(self, block_executor: BaseBlockExecutor,
-                 block_repo: Optional[BaseBlockClassRepository] = None):
-        super().__init__(block_repo)
+    def __init__(self, block_executor: Optional[BaseBlockExecutor] = None,
+                 block_repo: Optional[BaseBlockClassRepository] = None,
+                 allow_block_reuse: bool = True):
+        super().__init__(block_repo, allow_block_reuse=allow_block_reuse)
+        if block_executor is None:
+            block_executor = DefaultBlockExecutor()
         self.block_executor = block_executor
 
-    def _make_placeholder_fn(self, block: BaseBlock) -> Callable[..., EagerBlockWrapper]:
+    def _make_placeholder_fn(self, block: BaseBlock,
+                             state: Optional[PlaceholderFunctionState] = None) -> Callable[..., EagerBlockWrapper]:
         """Make a placeholder function for the block.
 
         Args:
@@ -40,7 +45,8 @@ class EagerPipelineBuilder(FunctionalPipelineBuilder):
             This function will execute the block.
 
         """
-        call_history = []
+        if state is None:
+            state = PlaceholderFunctionState(block)
 
         def placeholder_fn(*pfn_args, **pfn_kwargs) -> EagerBlockWrapper:
             """Execute the block with the given arguments.
@@ -55,8 +61,7 @@ class EagerPipelineBuilder(FunctionalPipelineBuilder):
                 Block wrapper.
 
             """
-            if len(call_history) > 0:
-                raise BlockReuseError(block)
+            block, producer_block = self._handle_block_reuse(state)
 
             if len(pfn_args) > 0:
                 assert len(pfn_kwargs) == 0, \
@@ -86,10 +91,13 @@ class EagerPipelineBuilder(FunctionalPipelineBuilder):
                     raise ValueError(
                         f'Wrong placeholder input type: {type(input_block_wrap_or_data)}'
                     )
+            if isinstance(block, SharedConsumer):
+                assert producer_block is not None
+                block_input_mapping[block.slots.inputs[block.input_block_name]] = producer_block.block
             eager_block = EagerBlockWrapper(block, executor=self.block_executor)
             if len(block_input_mapping) > 0:
                 eager_block.execute(block_input_mapping)
-            call_history.append(None)
+            self._register_block_wrapper(block, eager_block)
             return eager_block
 
         # make appropriate docstring and function signature

--- a/bosk/pipeline/builder/functional.py
+++ b/bosk/pipeline/builder/functional.py
@@ -222,10 +222,14 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
             '\n\n' + ('=' * (25 + len(repr(block)))) + '\n' \
             f'The block {block} documentation:\n\n' + \
             str(inspect.getdoc(block.__class__))
-        placeholder_fn.__signature__ = inspect.Signature([
-            inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY)
-            for name in block.slots.inputs.keys()
-        ])
+        setattr(
+            placeholder_fn,
+            '__signature__',
+            inspect.Signature([
+                inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY)
+                for name in block.slots.inputs.keys()
+            ])
+        )
         return placeholder_fn
 
     def wrap(self, block: BaseBlock) -> Callable[..., FunctionalBlockWrapper]:

--- a/bosk/pipeline/builder/functional.py
+++ b/bosk/pipeline/builder/functional.py
@@ -253,8 +253,8 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
             >>> result = rf(X=x)
 
         """
-        self._register_block(block)
         if block not in self._wrapped_states:
+            self._register_block(block)
             self._wrapped_states[block] = PlaceholderFunctionState(block)
         state = self._wrapped_states[block]
         return self._make_placeholder_fn(block, state=state)

--- a/bosk/pipeline/builder/functional.py
+++ b/bosk/pipeline/builder/functional.py
@@ -1,17 +1,26 @@
-import inspect
-from typing import Literal, Mapping, Type, Union
+from dataclasses import dataclass
+from ...block.placeholder import PlaceholderMixin
 from ...block import BaseBlock, BaseInputBlock, BaseOutputBlock
 from ...block.functional import FunctionalBlockWrapper
 from ...block.repo import BaseBlockClassRepository, DEFAULT_BLOCK_CLASS_REPOSITORY
 from ...block.base import BlockInputSlot, BlockOutputSlot
+from ...block.zoo.routing.shared import SharedProducer, SharedConsumer
 from ..connection import Connection
 from ..base import BasePipeline
 from .base import BasePipelineBuilder
 from ...exceptions import BlockReuseError
+import inspect
+from typing import Literal, Mapping, Set, Tuple, Type, Union
 from typing import List, Optional, Callable
+from collections import defaultdict
 
 
 SlotOrBlockWrapper = Union[BlockInputSlot, FunctionalBlockWrapper]
+
+
+@dataclass
+class PlaceholderFunctionState:
+    block: BaseBlock
 
 
 class FunctionalPipelineBuilder(BasePipelineBuilder):
@@ -24,14 +33,25 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
                     (without postfix "Block", for example:
                     :py:class:`bosk.block.zoo.data_conversion.ArgmaxBlock`
                     should be accessed as just "Argmax").
+        allow_block_reuse: If True, a block can be reused (which is implemented
+                           as replacing it in pipeline with SharedProducer or
+                           SharedConsumer), otherwise the exception `BlockReuseError`
+                           will be thrown if a block is encountered more than once.
 
     """
-    def __init__(self, block_repo: Optional[BaseBlockClassRepository] = None):
+
+    def __init__(self, block_repo: Optional[BaseBlockClassRepository] = None, allow_block_reuse: bool = True):
         self._nodes: List[BaseBlock] = []
         self._connections: List[Connection] = []
         if block_repo is None:
             block_repo = DEFAULT_BLOCK_CLASS_REPOSITORY
         self._block_repo: BaseBlockClassRepository = block_repo
+        self._called_blocks: Set[BaseBlock] = set()
+        self._block_wrappers: Mapping[BaseBlock,
+                                      List[FunctionalBlockWrapper]] = defaultdict(list)
+        self._wrapped_states: Mapping[PlaceholderMixin,
+                                      PlaceholderFunctionState] = dict()
+        self.allow_block_reuse = allow_block_reuse
 
     def __getattr__(self, name: str) -> Callable:
         block_cls = self._block_repo.get(name)
@@ -46,8 +66,110 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
         """
         self._nodes.append(block)
 
-    def _make_placeholder_fn(self, block: BaseBlock) -> Callable[..., FunctionalBlockWrapper]:
-        call_history = []
+    def _replace_block(self, replaced: BaseBlock, new: BaseBlock):
+        """Replace an existing block in the pipeline with a new one.
+
+        This method is used when a block needs to be updated or modified after it has already been added to the pipeline.
+
+        It's particularly useful in scenarios involving block reuse,
+        where a shared producer or consumer replaces a previously defined block instance.
+
+        Args:
+            replaced: The BaseBlock that needs to be replaced.
+            new: The new BaseBlock that will replace the old one.
+
+        """
+        # replace the block in nodes
+        replaced_index = self._nodes.index(replaced)
+        self._nodes[replaced_index] = new
+        # recreate connections
+        new_connections = []
+        for conn in self._connections:
+            if id(conn.src.parent_block) == id(replaced):
+                new_connections.append(Connection(
+                    src=new.slots.outputs[conn.src.meta.name],
+                    dst=conn.dst,
+                ))
+            elif id(conn.dst.parent_block) == id(replaced):
+                new_connections.append(Connection(
+                    src=conn.src,
+                    dst=new.slots.inputs[conn.dst.meta.name],
+                ))
+            else:
+                new_connections.append(conn)
+        self._connections = new_connections
+        # replace wrappers
+        block_wrappers = self._block_wrappers[replaced]
+        for wrapper in block_wrappers:
+            wrapper.set_block(new)
+        self._block_wrappers[new] = block_wrappers
+        del self._block_wrappers[replaced]
+
+    def _handle_block_reuse(self, state: PlaceholderFunctionState) -> Tuple[BaseBlock, Optional[SharedProducer]]:
+        """Handles the reuse of a block in the pipeline.
+
+        If `allow_block_reuse` is True, replaces the existing block with a SharedProducer or SharedConsumer.
+        Otherwise, raises a BlockReuseError if the block has already been encountered.
+
+        Args:
+            state: The current placeholder function state.
+
+        Returns:
+            A tuple containing the replaced block (either the original or a shared producer/consumer),
+            and an optional SharedProducer instance.
+
+            If `allow_block_reuse` is False, the first element of the tuple will be the original block,
+            and the second element will be None.
+            If `allow_block_reuse` is True, the first element will be either the original block
+            (if it is called once) or a new SharedConsumer instance,
+            and the second element will be the SharedProducer instance itself.
+
+        """
+        block = state.block
+        producer_block = None
+        if block in self._called_blocks or isinstance(block, SharedProducer):
+            if not self.allow_block_reuse:
+                raise BlockReuseError(block)
+            if not isinstance(block, SharedProducer):
+                producer_block = SharedProducer(
+                    block, output_block_name=f'__block_{id(block)}')
+                self._replace_block(block, producer_block)
+                state.block = producer_block
+            producer_block = state.block
+            assert isinstance(producer_block, SharedProducer)
+            # current block becomes the state consumer
+            block = SharedConsumer(
+                producer_block.meta,
+                input_block_name=producer_block.output_block_name,
+                default_output_name=producer_block.get_default_output().meta.name,
+            )
+            self._nodes.append(block)
+            self._connections.append(
+                Connection(
+                    src=producer_block.slots.outputs[producer_block.output_block_name],
+                    dst=block.slots.inputs[producer_block.output_block_name],
+                )
+            )
+        return block, producer_block
+
+    def _register_block_wrapper(self, block: BaseBlock, block_wrapper: FunctionalBlockWrapper):
+        """Register block wrapper.
+
+        Registers the result of a placeholder function call, allowing to track all
+        used block wrappers.
+
+        Args:
+            block: The called block.
+            block_wrapper: The created block wrapper.
+
+        """
+        self._called_blocks.add(block)
+        self._block_wrappers[block].append(block_wrapper)
+
+    def _make_placeholder_fn(self, block: BaseBlock,
+                             state: Optional[PlaceholderFunctionState] = None) -> Callable[..., FunctionalBlockWrapper]:
+        if state is None:
+            state = PlaceholderFunctionState(block)
 
         def placeholder_fn(*pfn_args, **pfn_kwargs) -> FunctionalBlockWrapper:
             """Placeholder function.
@@ -63,12 +185,13 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
                 *pfn_args: Not supported.
                 *pfn_kwargs: Inputs functional wrappers.
             """
-            if len(call_history) > 0:
-                raise BlockReuseError(block)
+            block, producer_block = self._handle_block_reuse(state)
 
             if len(pfn_args) != 0:
-                assert len(pfn_kwargs) == 0, "All arguments should be either named or unnamed"
-                assert len(block.slots.inputs), "Please, specify argument names: `block(arg1=value1, ..)`"
+                assert len(
+                    pfn_kwargs) == 0, "All arguments should be either named or unnamed"
+                assert len(
+                    block.slots.inputs), "Please, specify argument names: `block(arg1=value1, ..)`"
                 input_block_wrapper = pfn_args[0]
                 assert isinstance(input_block_wrapper, FunctionalBlockWrapper), \
                     f'Expected the argument is `FunctionalBlockWrapper` but got {type(input_block_wrapper)}. '\
@@ -90,13 +213,15 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
                         )
                     )
             # on success update call history
-            call_history.append(None)
-            return FunctionalBlockWrapper(block)
+            block_wrapper = FunctionalBlockWrapper(block)
+            self._register_block_wrapper(block, block_wrapper)
+            return block_wrapper
 
         # make appropriate docstring and function signature
         placeholder_fn.__doc__ = f'Execute the block {block} and get the result wrapper.' \
             '\n\n' + ('=' * (25 + len(repr(block)))) + '\n' \
-            f'The block {block} documentation:\n\n' + str(inspect.getdoc(block.__class__))
+            f'The block {block} documentation:\n\n' + \
+            str(inspect.getdoc(block.__class__))
         placeholder_fn.__signature__ = inspect.Signature([
             inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY)
             for name in block.slots.inputs.keys()
@@ -125,7 +250,10 @@ class FunctionalPipelineBuilder(BasePipelineBuilder):
 
         """
         self._register_block(block)
-        return self._make_placeholder_fn(block)
+        if block not in self._wrapped_states:
+            self._wrapped_states[block] = PlaceholderFunctionState(block)
+        state = self._wrapped_states[block]
+        return self._make_placeholder_fn(block, state=state)
 
     def _get_block_init(self, block_cls: Type[BaseBlock]) -> Callable[..., Callable[..., FunctionalBlockWrapper]]:
         """Get a new block initialization wrapper.

--- a/bosk/pipeline/serializer/skops.py
+++ b/bosk/pipeline/serializer/skops.py
@@ -2,8 +2,12 @@
 """
 from .base import BasePipelineSerializer, BaseBlockSerializer, BasePipeline
 from ...block.base import BaseBlock
-from skops.io import load as skops_load, dump as skops_dump
 from typing import Any, Optional
+
+try:
+    from skops.io import load as skops_load, dump as skops_dump
+except ImportError:
+    pass
 
 
 class SkopsBlockSerializer(BaseBlockSerializer):

--- a/examples/executors/parallel/greedy.py
+++ b/examples/executors/parallel/greedy.py
@@ -25,13 +25,13 @@ from bosk.block.auto import auto_block
 from joblib import parallel_backend
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y'})
 class ParallelRFC(RandomForestClassifier):
     def transform(self, X):
         return self.predict_proba(X)
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y'})
 class ParallelETC(ExtraTreesClassifier):
     def transform(self, X):
         return self.predict_proba(X)

--- a/tests/executors/parallel_test.py
+++ b/tests/executors/parallel_test.py
@@ -20,13 +20,13 @@ from ..utility import log_test_name
 import logging
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y'})
 class ParallelRFC(RandomForestClassifier):
     def transform(self, X):
         return CPUData(self.predict_proba(X))
 
 
-@auto_block(execution_props=BlockExecutionProperties(threadsafe=True))
+@auto_block(execution_props=BlockExecutionProperties(threadsafe=True), fit_argnames={'X', 'y'})
 class ParallelETC(ExtraTreesClassifier):
     def transform(self, X):
         return CPUData(self.predict_proba(X))

--- a/tests/pipelines/block_reuse_test.py
+++ b/tests/pipelines/block_reuse_test.py
@@ -1,0 +1,151 @@
+"""Eager evaluations tests."""
+
+from typing import Dict, Optional, Sequence, Tuple
+from bosk.pipeline.base import BasePipeline
+from bosk.data import BaseData, CPUData
+from bosk.executor.topological import TopologicalExecutor
+from bosk.pipeline.builder.eager import EagerPipelineBuilder
+from bosk.stages import Stage
+from ..utility import fit_pipeline, log_test_name
+from sklearn.datasets import make_moons
+from sklearn.model_selection import train_test_split
+import numpy as np
+import logging
+
+from bosk.pipeline.builder import FunctionalPipelineBuilder
+from bosk.block.zoo.input_plugs import Input, TargetInput
+from bosk.block.zoo.data_conversion import Argmax, Average, Concat, Stack
+from bosk.block.zoo.models.classification import RFC, ETC
+from bosk.block.zoo.models.regression import RFR, ETR
+from bosk.block.zoo.output_plugs import Output
+from bosk.block.zoo.metrics import RocAuc
+
+
+class FunctionalBlockReuseTest:
+    """Test case of the basic deep forest constructed with functional pipeline."""
+
+    random_seed = 42
+    executor_cls = TopologicalExecutor
+
+    def reuse_twice_test(self):
+        all_X, all_y = make_moons(noise=0.5, random_state=self.random_seed)
+        train_X, test_X, train_y, test_y = train_test_split(
+            all_X,
+            all_y,
+            test_size=0.2,
+            random_state=self.random_seed
+        )
+
+        with FunctionalPipelineBuilder() as b:
+            X, y = Input()(), TargetInput()()
+            X2 = Input()()
+            X3 = Input()()
+
+            rfr = RFR()
+            out1 = rfr(X=X, y=y)
+            out2 = rfr(X=X2)  # reuse
+            out3 = rfr(X=X3)  # reuse
+
+            pipeline = b.build(
+                {'X': X, 'y': y, 'X2': X2, 'X3': X3},
+                {'out1': out1 , 'out2': out2, 'out3': out3},
+            )
+
+        fit_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.FIT,
+        )
+        transform_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.TRANSFORM,
+        )
+
+        fit_executor({'X': train_X, 'y': train_y, 'X2': train_X[:10], 'X3': train_X[:7]})
+        train_result = transform_executor({'X': train_X, 'X2': test_X, 'X3': test_X[:5]}).numpy()
+        assert train_result['out1'].shape[0] == train_X.shape[0]
+        assert train_result['out2'].shape[0] == test_X.shape[0]
+        assert train_result['out3'].shape[0] == 5
+
+    def reuse_separately_test(self):
+        all_X, all_y = make_moons(noise=0.5, random_state=self.random_seed)
+        train_X, test_X, train_y, test_y = train_test_split(
+            all_X,
+            all_y,
+            test_size=0.2,
+            random_state=self.random_seed
+        )
+
+        with FunctionalPipelineBuilder() as b:
+            X, y = Input()(), TargetInput()()
+            X2 = Input()()
+            X3 = Input()()
+
+            rfr = RFR()
+            out1 = rfr(X=X, y=y)
+            out2 = rfr(X=X2)  # reuse
+            out3 = rfr(X=X3)  # reuse
+
+            pipeline = b.build(
+                {'X': X, 'y': y, 'X2': X2, 'X3': X3},
+                {'out1': out1 , 'out2': out2, 'out3': out3},
+            )
+
+        fit_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.FIT,
+            inputs=['X', 'y'],
+            outputs=['out1'],
+
+        )
+        transform_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.TRANSFORM,
+            inputs=['X', 'X2', 'X3'],
+            outputs=['out2', 'out3'],
+        )
+
+        fit_executor({'X': train_X, 'y': train_y})
+        train_result = transform_executor({'X': test_X, 'X2': test_X, 'X3': test_X[:5]}).numpy()
+        assert train_result['out2'].shape[0] == test_X.shape[0]
+        assert train_result['out3'].shape[0] == 5
+
+
+class EagerBlockReuseTest:
+    """Test case of the basic deep forest constructed with functional pipeline."""
+
+    random_seed = 42
+    executor_cls = TopologicalExecutor
+
+    def reuse_twice_test(self):
+        all_X, all_y = make_moons(noise=0.5, random_state=self.random_seed)
+        train_X, test_X, train_y, test_y = train_test_split(
+            all_X,
+            all_y,
+            test_size=0.2,
+            random_state=self.random_seed
+        )
+
+        with EagerPipelineBuilder() as b:
+            X, y = Input()(train_X), TargetInput()(train_y)
+            X2 = Input()(test_X)
+            X3 = Input()(test_X[:5])
+
+            rfr = RFR()
+            out1 = rfr(X=X, y=y)
+            out2 = rfr(X=X2)  # reuse
+            out3 = rfr(X=X3)  # reuse
+
+            pipeline = b.build(
+                {'X': X, 'y': y, 'X2': X2, 'X3': X3},
+                {'out1': out1 , 'out2': out2, 'out3': out3},
+            )
+
+        transform_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.TRANSFORM,
+        )
+
+        train_result = transform_executor({'X': train_X, 'X2': test_X, 'X3': test_X[:5]}).numpy()
+        assert np.allclose(out1.data, train_result['out1'])
+        assert np.allclose(out2.data, train_result['out2'])
+        assert np.allclose(out3.data, train_result['out3'])

--- a/tests/pipelines/functional_test.py
+++ b/tests/pipelines/functional_test.py
@@ -1,0 +1,76 @@
+"""Eager evaluations tests."""
+
+from typing import Dict, Optional, Sequence, Tuple
+from bosk.pipeline.base import BasePipeline
+from bosk.data import BaseData, CPUData
+from bosk.executor.topological import TopologicalExecutor
+from bosk.stages import Stage
+from ..utility import fit_pipeline, log_test_name
+from sklearn.datasets import make_moons
+from sklearn.model_selection import train_test_split
+import numpy as np
+import logging
+
+from bosk.pipeline.builder import FunctionalPipelineBuilder
+from bosk.block.zoo.input_plugs import Input, TargetInput
+from bosk.block.zoo.data_conversion import Argmax, Average, Concat, Stack
+from bosk.block.zoo.models.classification import RFC, ETC
+from bosk.block.zoo.models.regression import RFR, ETR
+from bosk.block.zoo.output_plugs import Output
+from bosk.block.zoo.metrics import RocAuc
+
+
+class FunctionalPipelineTest:
+    """Test case of the basic deep forest constructed with functional pipeline."""
+
+    random_seed = 42
+    executor_cls = TopologicalExecutor
+
+    def functional_fit_transform_test(self):
+        all_X, all_y = make_moons(noise=0.5, random_state=self.random_seed)
+        train_X, test_X, train_y, test_y = train_test_split(
+            all_X,
+            all_y,
+            test_size=0.2,
+            random_state=self.random_seed
+        )
+
+        with FunctionalPipelineBuilder() as b:
+            X, y = Input()(), TargetInput()()
+            forest_params = dict(n_estimators=3, max_depth=2)
+
+            rf_1 = RFC(random_state=self.random_seed, **forest_params)(X=X, y=y)
+            et_1 = ETC(random_state=self.random_seed, **forest_params)(X=X, y=y)
+            concat_1 = Concat(['X', 'rf_1', 'et_1'])(X=X, rf_1=rf_1, et_1=et_1)
+            rf_2 = RFC(random_state=self.random_seed, **forest_params)(X=concat_1, y=y)
+            et_2 = ETC(random_state=self.random_seed, **forest_params)(X=concat_1, y=y)
+            concat_2 = Concat(['X', 'rf_2', 'et_2'])(X=X, rf_2=rf_2, et_2=et_2)
+            rf_3 = RFC(random_state=self.random_seed, **forest_params)(X=concat_2, y=y)
+            et_3 = ETC(random_state=self.random_seed, **forest_params)(X=concat_2, y=y)
+            stack_3 = Stack(['rf_3', 'et_3'], axis=1)(rf_3=rf_3, et_3=et_3)
+            average_3 = Average(axis=1)(X=stack_3)
+            argmax_3 = Argmax(axis=1)(X=average_3)
+
+            rf_1_roc_auc = RocAuc()(gt_y=y, pred_probas=rf_1)
+            roc_auc = RocAuc()(gt_y=y, pred_probas=average_3)
+
+            pipeline = b.build(
+                {'X': X, 'y': y},
+                {'probas': average_3, 'rf_1_roc-auc': rf_1_roc_auc, 'roc-auc': roc_auc, 'labels': argmax_3}
+            )
+
+        fit_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.FIT,
+            inputs=['X', 'y'],
+            outputs=['probas', 'rf_1_roc-auc', 'roc-auc'],
+        )
+        transform_executor = self.executor_cls(
+            pipeline,
+            stage=Stage.TRANSFORM,
+            inputs=['X'],
+            outputs=['probas', 'labels'],
+        )
+
+        fit_executor({'X': train_X, 'y': train_y})
+        train_result = transform_executor({'X': CPUData(train_X)})

--- a/tests/pipelines/weighted_cs_test.py
+++ b/tests/pipelines/weighted_cs_test.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Sequence, Tuple
 
 class WeightedCSForestTest(BPT):
 
-    n_trees: int = 23
+    n_trees: int = 7
 
     def make_deep_forest_layer(self, b, **inputs):
         rf = b.RFC(n_estimators=self.n_trees)(**inputs)
@@ -21,8 +21,8 @@ class WeightedCSForestTest(BPT):
     def _get_pipeline(self):
         b = FunctionalPipelineBuilder()
         X, y = b.Input()(), b.TargetInput()()
-        rf_1 = b.RFC()(X=X, y=y)
-        et_1 = b.ETC()(X=X, y=y)
+        rf_1 = b.RFC(n_estimators=self.n_trees, random_state=1)(X=X, y=y)
+        et_1 = b.ETC(n_estimators=self.n_trees, random_state=2)(X=X, y=y)
         concat_1 = b.Concat(['rf_1', 'et_1'])(rf_1=rf_1, et_1=et_1)
         stack_1 = b.Stack(['rf_1', 'et_1'], axis=1)(rf_1=rf_1, et_1=et_1)
         average_1 = b.Average(axis=1)(X=stack_1)


### PR DESCRIPTION
The **Shared Blocks** have been introduced in order to handle block reuse when constructing a pipeline with **Functional** or **Eager** builder.

For example, the following code previously resulted in an error:

```python
with FunctionalPipelineBuilder() as b:
    X, y = Input()(), TargetInput()()
    X2 = Input()()
    X3 = Input()()

    rfr = RFR()
    out1 = rfr(X=X, y=y)
    out2 = rfr(X=X2)  # here the block `rfr` is reused
    out3 = rfr(X=X3)  # ... reused the second time

    pipeline = b.build(
        {'X': X, 'y': y, 'X2': X2, 'X3': X3},
        {'out1': out1 , 'out2': out2, 'out3': out3},
    )
```

Now `FunctionalPipelineBuilder(allow_block_reuse=True)` (True is the default value) would handle block reuse in
the following way:

- The first block usage is replaced with `SharedProducer` (wrapper), which incorporates the original block. This wrapper outputs all outputs of the original block and additionally the underlying block itself;
- Each block reusage is replaced with `SharedConsumer`, which has no state and receives the original block state as an input.

Additionally, some docstrings, small mistakes and typing errors have been fixed.